### PR TITLE
Always set `additionalProperties`

### DIFF
--- a/pkg/jsonschema/json-schema.go
+++ b/pkg/jsonschema/json-schema.go
@@ -28,6 +28,8 @@ func CreateSchema(path string, strict bool) (map[string]any, error) {
 
 	if strict {
 		schemaOut["additionalProperties"] = false
+	} else {
+		schemaOut["additionalProperties"] = true
 	}
 
 	properties := make(map[string]any)

--- a/pkg/jsonschema/type.go
+++ b/pkg/jsonschema/type.go
@@ -86,6 +86,8 @@ func getObject(in []any, strict bool) (map[string]any, error) {
 	}
 	if strict {
 		node["additionalProperties"] = false
+	} else {
+		node["additionalProperties"] = true
 	}
 
 	if len(in) != 2 && len(in) != 3 {

--- a/test/expected/complex-types/schema.json
+++ b/test/expected/complex-types/schema.json
@@ -1,7 +1,9 @@
 {
     "$schema": "http://json-schema.org/draft-07/schema#",
+    "additionalProperties": true,
     "properties": {
         "a_very_complicated_object": {
+            "additionalProperties": true,
             "default": {
                 "b": [
                     [
@@ -80,6 +82,7 @@
                     "type": "object"
                 },
                 "d": {
+                    "additionalProperties": true,
                     "properties": {
                         "a": {
                             "items": {
@@ -134,6 +137,7 @@
             "type": "object"
         },
         "an_object_with_optional": {
+            "additionalProperties": true,
             "default": {
                 "a": "a",
                 "b": 1,

--- a/test/expected/custom-validation/schema.json
+++ b/test/expected/custom-validation/schema.json
@@ -1,5 +1,6 @@
 {
     "$schema": "http://json-schema.org/draft-07/schema#",
+    "additionalProperties": true,
     "properties": {
         "a_list_maximum_minimum_length": {
             "default": [
@@ -164,6 +165,7 @@
             "type": "string"
         },
         "an_object_maximum_minimum_items": {
+            "additionalProperties": true,
             "default": {
                 "name": "a",
                 "other_field": "b"

--- a/test/expected/simple-types/schema.json
+++ b/test/expected/simple-types/schema.json
@@ -1,5 +1,6 @@
 {
     "$schema": "http://json-schema.org/draft-07/schema#",
+    "additionalProperties": true,
     "properties": {
         "a_bool": {
             "default": false,
@@ -94,6 +95,7 @@
             "type": "string"
         },
         "an_object": {
+            "additionalProperties": true,
             "default": {
                 "a": "a",
                 "b": 1,

--- a/test/expected/simple/schema.json
+++ b/test/expected/simple/schema.json
@@ -1,5 +1,6 @@
 {
     "$schema": "http://json-schema.org/draft-07/schema#",
+    "additionalProperties": true,
     "properties": {
         "age": {
             "description": "Your age. Required.",


### PR DESCRIPTION
This is done to make it easier to distinguish whether additional properties are allowed or not in a schema.

Note: additional properties are always ignored by terraform, and will create a warning if any are set.

External behaviour of the schemas themselves are not changed since `additionalProperties: true` is equivalent to not setting it.