### PR TITLE
Add debug logging option

### DIFF
--- a/pkg/jsonschema/value_test.go
+++ b/pkg/jsonschema/value_test.go
@@ -37,7 +37,7 @@ func TestExpressionToJSONObject_Default(t *testing.T) {
 
 			defaults := make(map[string]any)
 
-			varMap, err := reader.GetVarMap(filepath.Join(tfPath, name))
+			varMap, err := reader.GetVarMap(filepath.Join(tfPath, name), true)
 			if err != nil && !errors.Is(err, reader.ErrFilesNotFound) {
 				t.Errorf("error reading tf files: %v", err)
 			}

--- a/pkg/reader/reader_test.go
+++ b/pkg/reader/reader_test.go
@@ -21,7 +21,7 @@ func TestGetVarMap_Required(t *testing.T) {
 		name := testCases[i]
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()
-			varMap, err := GetVarMap(filepath.Join(tfPath, name))
+			varMap, err := GetVarMap(filepath.Join(tfPath, name), true)
 			if err != nil && !errors.Is(err, ErrFilesNotFound) {
 				t.Errorf("Error reading tf files: %v", err)
 			}

--- a/pkg/reader/type-constraint_test.go
+++ b/pkg/reader/type-constraint_test.go
@@ -30,7 +30,7 @@ func TestGetTypeConstraint(t *testing.T) {
 			expected, err := os.ReadFile(filepath.Join(expectedPath, name, "type-constraints.json"))
 			require.NoError(t, err)
 
-			varMap, err := GetVarMap(filepath.Join(tfPath, name))
+			varMap, err := GetVarMap(filepath.Join(tfPath, name), true)
 			if err != nil && !errors.Is(err, ErrFilesNotFound) {
 				t.Errorf("Error reading tf files: %v", err)
 			}


### PR DESCRIPTION
And fix stdout so nothing except the schema prints (unless there is an error).

Also add debug logging for the reader package, and for validation rules.

```
Debug: found the following files in "/home/aisling/dev/HewlettPackard/terraschema/test/modules/simple":
        "/home/aisling/dev/HewlettPackard/terraschema/test/modules/simple/main.tf", with variable(s):
        "/home/aisling/dev/HewlettPackard/terraschema/test/modules/simple/variables.tf", with variable(s):
                name
                age
Warning: couldn't apply validation for "age" with condition "var.age > env.age": no translation rules are supported for this condition
Debug: condition located at "/home/aisling/dev/HewlettPackard/terraschema/test/modules/simple/variables.tf:14,21-38"
Debug: the following errors occurred:
        contains([...],var.input_parameter): condition is not a 'contains()' function
        var == "a" || var == "b": operator is not || or ==
        a <>= (variable or variable length) (&& ...): could not evaluate expression as a constant value: /home/aisling/dev/HewlettPackard/terraschema/test/modules/simple/variables.tf:14,31-34: Variables not allowed; Variables may not be used here.
        can(regex("...",var.input_parameter)): rule can only be applied to string types, not "number"
Schema written to "/home/aisling/dev/HewlettPackard/terraschema/schema.json"
```