### PR TITLE
Add `make` and `make clean`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 vendor
 .vscode
+terraschema

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,5 @@
 # Copyright 2024 Hewlett Packard Enterprise Development LP
+.DEFAULT_GOAL := terraschema
 
 .PHONY: test
 test: 
@@ -10,3 +11,11 @@ lint:
 
 .PHONY: all
 all: test lint
+
+.PHONY: terraschema
+terraschema: 
+	@go build .
+
+.PHONY: clean
+clean:
+	@rm -f terraschema


### PR DESCRIPTION
In case people clone the repository and want to quickly build the binary from source, as an alternative to `go install github.com/HewlettPackard/terraschema@latest`