### PR TITLE
fix: add top level `type` property

### DIFF
--- a/pkg/jsonschema/json-schema.go
+++ b/pkg/jsonschema/json-schema.go
@@ -36,7 +36,7 @@ func CreateSchema(path string, options CreateSchemaOptions) (map[string]any, err
 	}
 
 	schemaOut["$schema"] = "http://json-schema.org/draft-07/schema#"
-
+	schemaOut["type"] = "object"
 	schemaOut["additionalProperties"] = options.AllowAdditionalProperties
 
 	properties := make(map[string]any)

--- a/test/expected/complex-types/schema-disallow-additional.json
+++ b/test/expected/complex-types/schema-disallow-additional.json
@@ -166,5 +166,6 @@
 			"type": "object"
 		}
 	},
-	"required": []
+	"required": [],
+	"type": "object"
 }

--- a/test/expected/complex-types/schema-nullable-all.json
+++ b/test/expected/complex-types/schema-nullable-all.json
@@ -186,5 +186,6 @@
 			"title": "an_object_with_optional: Select a type"
 		}
 	},
-	"required": []
+	"required": [],
+	"type": "object"
 }

--- a/test/expected/complex-types/schema.json
+++ b/test/expected/complex-types/schema.json
@@ -166,5 +166,6 @@
 			"type": "object"
 		}
 	},
-	"required": []
+	"required": [],
+	"type": "object"
 }

--- a/test/expected/custom-validation/schema-disallow-additional.json
+++ b/test/expected/custom-validation/schema-disallow-additional.json
@@ -192,5 +192,6 @@
 			"type": "object"
 		}
 	},
-	"required": []
+	"required": [],
+	"type": "object"
 }

--- a/test/expected/custom-validation/schema-nullable-all.json
+++ b/test/expected/custom-validation/schema-nullable-all.json
@@ -362,5 +362,6 @@
 			"title": "an_object_maximum_minimum_items: Select a type"
 		}
 	},
-	"required": []
+	"required": [],
+	"type": "object"
 }

--- a/test/expected/custom-validation/schema.json
+++ b/test/expected/custom-validation/schema.json
@@ -192,5 +192,6 @@
 			"type": "object"
 		}
 	},
-	"required": []
+	"required": [],
+	"type": "object"
 }

--- a/test/expected/simple-types/schema-disallow-additional.json
+++ b/test/expected/simple-types/schema-disallow-additional.json
@@ -124,5 +124,6 @@
 	"required": [
 		"a_nullable_string",
 		"a_number"
-	]
+	],
+	"type": "object"
 }

--- a/test/expected/simple-types/schema-nullable-all.json
+++ b/test/expected/simple-types/schema-nullable-all.json
@@ -214,5 +214,6 @@
 	"required": [
 		"a_nullable_string",
 		"a_number"
-	]
+	],
+	"type": "object"
 }

--- a/test/expected/simple-types/schema.json
+++ b/test/expected/simple-types/schema.json
@@ -124,5 +124,6 @@
 	"required": [
 		"a_nullable_string",
 		"a_number"
-	]
+	],
+	"type": "object"
 }

--- a/test/expected/simple/schema-disallow-additional.json
+++ b/test/expected/simple/schema-disallow-additional.json
@@ -14,5 +14,6 @@
 	},
 	"required": [
 		"age"
-	]
+	],
+	"type": "object"
 }

--- a/test/expected/simple/schema-nullable-all.json
+++ b/test/expected/simple/schema-nullable-all.json
@@ -34,5 +34,6 @@
 	},
 	"required": [
 		"age"
-	]
+	],
+	"type": "object"
 }

--- a/test/expected/simple/schema.json
+++ b/test/expected/simple/schema.json
@@ -14,5 +14,6 @@
 	},
 	"required": [
 		"age"
-	]
+	],
+	"type": "object"
 }


### PR DESCRIPTION
According to https://json-schema.org/draft-07/draft-handrews-json-schema-validation-01\#rfc.section.6.1.1, the `type` property must be defined.

This pull request adds the `"type": "object"` to the top level schema definition.

Without this property, generators may omit the schema entirely because they expect to find a top level object schema and do not default to the "object" value.

---

For more details, see https://github.com/omissis/go-jsonschema/issues/171#issuecomment-2675885883