### PR TITLE
fix: remove extra `additionalProperties` on nested objects

### DIFF
--- a/pkg/jsonschema/type.go
+++ b/pkg/jsonschema/type.go
@@ -154,7 +154,14 @@ func getMap(in []any, options CreateSchemaOptions) (map[string]any, error) {
 	if err != nil {
 		return nil, fmt.Errorf("map: %w", err)
 	}
-	node["additionalProperties"] = newNode
+
+	if newNode["type"] == "object" {
+		for k, v := range newNode {
+			node[k] = v
+		}
+	} else {
+		node["additionalProperties"] = newNode
+	}
 
 	return node, nil
 }

--- a/test/expected/complex-types/schema.json
+++ b/test/expected/complex-types/schema.json
@@ -2,6 +2,37 @@
 	"$schema": "http://json-schema.org/draft-07/schema#",
 	"additionalProperties": true,
 	"properties": {
+		"a_nested_object": {
+			"additionalProperties": true,
+			"description": "This is a nested object",
+			"type": "object",
+			"properties": {
+				"c": {
+					"type": "object",
+					"additionalProperties": true,
+					"properties": {
+						"cc": {
+							"type": "object",
+							"additionalProperties": true,
+							"properties": {
+								"ccc": {
+									"type": "string"
+								}
+							},
+							"required": [
+								"ccc"
+							]
+						}
+					},
+					"required": [
+						"cc"
+					]
+				}
+			},
+			"required": [
+				"c"
+			]
+		},
 		"a_very_complicated_object": {
 			"additionalProperties": true,
 			"default": {
@@ -166,5 +197,5 @@
 			"type": "object"
 		}
 	},
-	"required": []
+	"required": ["a_nested_object"]
 }

--- a/test/modules/complex-types/variables.tf
+++ b/test/modules/complex-types/variables.tf
@@ -42,3 +42,14 @@ variable "a_very_complicated_object" {
     }
     description = "This is a very complicated object"
 }
+
+variable "a_nested_object" {
+    type = object({
+        c = map(object({
+            cc = map(object({
+                ccc = string
+            }))
+        }))
+    })
+    description = "This is a nested object"
+}


### PR DESCRIPTION
An extra check for the type has been added, which will either add additional properties to the `additionalProperties` or the current object properties.

Closes #32