### PR TITLE
fix: remove extra `additionalProperties` on nested objects

### DIFF
--- a/pkg/jsonschema/type.go
+++ b/pkg/jsonschema/type.go
@@ -154,7 +154,14 @@ func getMap(in []any, options CreateSchemaOptions) (map[string]any, error) {
 	if err != nil {
 		return nil, fmt.Errorf("map: %w", err)
 	}
-	node["additionalProperties"] = newNode
+
+	if newNode["type"] == "object" {
+		for k, v := range newNode {
+			node[k] = v
+		}
+	} else {
+		node["additionalProperties"] = newNode
+	}
 
 	return node, nil
 }

--- a/test/expected/complex-types/schema-disallow-additional.json
+++ b/test/expected/complex-types/schema-disallow-additional.json
@@ -2,6 +2,44 @@
 	"$schema": "http://json-schema.org/draft-07/schema#",
 	"additionalProperties": false,
 	"properties": {
+		"a_nested_object": {
+			"additionalProperties": false,
+			"default": {
+				"c": {
+					"cc": {
+						"ccc": "c"
+					}
+				}
+			},
+			"description": "This is a nested object",
+			"properties": {
+				"c": {
+					"additionalProperties": false,
+					"properties": {
+						"cc": {
+							"additionalProperties": false,
+							"properties": {
+								"ccc": {
+									"type": "string"
+								}
+							},
+							"required": [
+								"ccc"
+							],
+							"type": "object"
+						}
+					},
+					"required": [
+						"cc"
+					],
+					"type": "object"
+				}
+			},
+			"required": [
+				"c"
+			],
+			"type": "object"
+		},
 		"a_very_complicated_object": {
 			"additionalProperties": false,
 			"default": {

--- a/test/expected/complex-types/schema-nullable-all.json
+++ b/test/expected/complex-types/schema-nullable-all.json
@@ -2,6 +2,54 @@
 	"$schema": "http://json-schema.org/draft-07/schema#",
 	"additionalProperties": true,
 	"properties": {
+		"a_nested_object": {
+			"anyOf": [
+				{
+					"title": "null",
+					"type": "null"
+				},
+				{
+					"additionalProperties": true,
+					"properties": {
+						"c": {
+							"additionalProperties": true,
+							"properties": {
+								"cc": {
+									"additionalProperties": true,
+									"properties": {
+										"ccc": {
+											"type": "string"
+										}
+									},
+									"required": [
+										"ccc"
+									],
+									"type": "object"
+								}
+							},
+							"required": [
+								"cc"
+							],
+							"type": "object"
+						}
+					},
+					"required": [
+						"c"
+					],
+					"title": "object",
+					"type": "object"
+				}
+			],
+			"default": {
+				"c": {
+					"cc": {
+						"ccc": "c"
+					}
+				}
+			},
+			"description": "This is a nested object",
+			"title": "a_nested_object: Select a type"
+		},
 		"a_very_complicated_object": {
 			"anyOf": [
 				{

--- a/test/expected/complex-types/schema.json
+++ b/test/expected/complex-types/schema.json
@@ -4,15 +4,19 @@
 	"properties": {
 		"a_nested_object": {
 			"additionalProperties": true,
+			"default": {
+				"c": {
+					"cc": {
+						"ccc": "c"
+					}
+				}
+			},
 			"description": "This is a nested object",
-			"type": "object",
 			"properties": {
 				"c": {
-					"type": "object",
 					"additionalProperties": true,
 					"properties": {
 						"cc": {
-							"type": "object",
 							"additionalProperties": true,
 							"properties": {
 								"ccc": {
@@ -21,17 +25,20 @@
 							},
 							"required": [
 								"ccc"
-							]
+							],
+							"type": "object"
 						}
 					},
 					"required": [
 						"cc"
-					]
+					],
+					"type": "object"
 				}
 			},
 			"required": [
 				"c"
-			]
+			],
+			"type": "object"
 		},
 		"a_very_complicated_object": {
 			"additionalProperties": true,
@@ -197,8 +204,6 @@
 			"type": "object"
 		}
 	},
-	"required": [
-		"a_nested_object"
-	],
+	"required": [],
 	"type": "object"
 }

--- a/test/expected/complex-types/schema.json
+++ b/test/expected/complex-types/schema.json
@@ -2,6 +2,37 @@
 	"$schema": "http://json-schema.org/draft-07/schema#",
 	"additionalProperties": true,
 	"properties": {
+		"a_nested_object": {
+			"additionalProperties": true,
+			"description": "This is a nested object",
+			"type": "object",
+			"properties": {
+				"c": {
+					"type": "object",
+					"additionalProperties": true,
+					"properties": {
+						"cc": {
+							"type": "object",
+							"additionalProperties": true,
+							"properties": {
+								"ccc": {
+									"type": "string"
+								}
+							},
+							"required": [
+								"ccc"
+							]
+						}
+					},
+					"required": [
+						"cc"
+					]
+				}
+			},
+			"required": [
+				"c"
+			]
+		},
 		"a_very_complicated_object": {
 			"additionalProperties": true,
 			"default": {
@@ -166,6 +197,8 @@
 			"type": "object"
 		}
 	},
-	"required": [],
+	"required": [
+		"a_nested_object"
+	],
 	"type": "object"
 }

--- a/test/expected/complex-types/variables.json
+++ b/test/expected/complex-types/variables.json
@@ -1,4 +1,36 @@
 {
+	"a_nested_object": {
+		"default": {
+			"c": {
+				"cc": {
+					"ccc": "c"
+				}
+			}
+		},
+		"description": "This is a nested object",
+		"type": [
+			"object",
+			{
+				"c": [
+					"map",
+					[
+						"object",
+						{
+							"cc": [
+								"map",
+								[
+									"object",
+									{
+										"ccc": "string"
+									}
+								]
+							]
+						}
+					]
+				]
+			}
+		]
+	},
 	"a_very_complicated_object": {
 		"default": {
 			"b": [

--- a/test/modules/complex-types/variables.tf
+++ b/test/modules/complex-types/variables.tf
@@ -42,3 +42,14 @@ variable "a_very_complicated_object" {
     }
     description = "This is a very complicated object"
 }
+
+variable "a_nested_object" {
+    type = object({
+        c = map(object({
+            cc = map(object({
+                ccc = string
+            }))
+        }))
+    })
+    description = "This is a nested object"
+}

--- a/test/modules/complex-types/variables.tf
+++ b/test/modules/complex-types/variables.tf
@@ -51,5 +51,12 @@ variable "a_nested_object" {
             }))
         }))
     })
+    default = {
+        c = {
+            cc = {
+                ccc = "c"
+            }
+        }
+    }
     description = "This is a nested object"
 }


### PR DESCRIPTION
An extra check for the type has been added, which will either add additional properties to the additionalProperties or the current object properties.

Closes #32 

Replaces #33 