### PR TITLE
Allow mulitple validation blocks

### DIFF
--- a/pkg/json/json.go
+++ b/pkg/json/json.go
@@ -29,12 +29,12 @@ type MarshallableVariableBlock struct {
 var _ json.Marshaler = MarshallableVariableBlock{}
 
 type JSONVariableBlock struct {
-	Default     *any                 `json:"default,omitempty"`
-	Description *string              `json:"description,omitempty"`
-	Nullable    *bool                `json:"nullable,omitempty"`
-	Sensitive   *bool                `json:"sensitive,omitempty"`
-	Validation  *JSONValidationBlock `json:"validation,omitempty"`
-	Type        *any                 `json:"type,omitempty"`
+	Default     *any                  `json:"default,omitempty"`
+	Description *string               `json:"description,omitempty"`
+	Nullable    *bool                 `json:"nullable,omitempty"`
+	Sensitive   *bool                 `json:"sensitive,omitempty"`
+	Validations []JSONValidationBlock `json:"validation,omitempty"`
+	Type        *any                  `json:"type,omitempty"`
 }
 
 type JSONValidationBlock struct {
@@ -83,13 +83,16 @@ func (j MarshallableVariableBlock) MarshalJSON() ([]byte, error) {
 	}
 	translatedBlock.Default = &translatedDefault
 
-	if j.Variable.Validation != nil {
-		if j.ConditionAsString == nil {
-			return nil, errors.New("validation block present with no condition")
+	if len(j.Variable.Validations) != 0 {
+		if len(j.ConditionsAsString) != len(j.Variable.Validations) {
+			return nil, errors.New("mismatch between the number of validation blocks and conditions")
 		}
-		translatedBlock.Validation = &JSONValidationBlock{
-			Condition:    *j.ConditionAsString,
-			ErrorMessage: j.Variable.Validation.ErrorMessage,
+		translatedBlock.Validations = make([]JSONValidationBlock, len(j.Variable.Validations))
+		for i := range translatedBlock.Validations {
+			translatedBlock.Validations[i] = JSONValidationBlock{
+				Condition:    j.ConditionsAsString[i],
+				ErrorMessage: j.Variable.Validations[i].ErrorMessage,
+			}
 		}
 	}
 

--- a/pkg/jsonschema/json-schema_test.go
+++ b/pkg/jsonschema/json-schema_test.go
@@ -298,6 +298,7 @@ func TestSampleInput(t *testing.T) {
 				{name: "/properties/a_string_enum_kind_1/enum"},
 				{name: "/properties/a_string_enum_kind_2/type"},
 				{name: "/properties/a_string_maximum_minimum_length/maxLength"},
+				{name: "/properties/a_string_multiple_validation_conditions/minLength"},
 				{name: "/properties/a_string_pattern_1/pattern"},
 				{name: "/properties/a_string_pattern_2/pattern"},
 				{
@@ -362,6 +363,7 @@ func TestSampleInput(t *testing.T) {
 				{name: "/properties/a_string_enum_kind_2/type"},
 				{name: "/properties/a_string_length_over_defined/type"},
 				{name: "/properties/a_string_maximum_minimum_length/type"},
+				{name: "/properties/a_string_multiple_validation_conditions/type"},
 				{name: "/properties/a_string_pattern_1/type"},
 				{name: "/properties/a_string_pattern_2/type"},
 				{name: "/properties/a_string_set_length/type"},

--- a/pkg/model/model.go
+++ b/pkg/model/model.go
@@ -13,10 +13,10 @@ type VariableBlock struct {
 	Nullable    *bool          `hcl:"nullable,optional"`
 	// Sensitive is ignored.
 	Sensitive *bool `hcl:"sensitive,optional"`
-	// Validation blocks can be used to add extra rules to the JSON schema, as long as their conditions
+	// Validations blocks can be used to add extra rules to the JSON schema, as long as their conditions
 	// are written in a certain format.
-	Validation *ValidationBlock `hcl:"validation,block"`
-	Type       hcl.Expression   `hcl:"type,optional"`
+	Validations []ValidationBlock `hcl:"validation,block"`
+	Type        hcl.Expression    `hcl:"type,optional"`
 }
 
 type ValidationBlock struct {
@@ -29,8 +29,8 @@ type ValidationBlock struct {
 // This is done here because it can be difficult to extract this information from pure hcl.Expressions as present in
 // the Variable struct without further context. Required is used internally, and the others are for debugging.
 type TranslatedVariable struct {
-	// if the variable has a validation block, this stores its condition as a string. This is useful for debugging.
-	ConditionAsString *string
+	// if the variable has validation blocks, this stores their conditions as a string. This is useful for debugging.
+	ConditionsAsString []string
 	// DefaultAsString is the default value of the variable, as a string. This is useful for debugging complex default values.
 	DefaultAsString *string
 	// TypeAsString is the type of the variable, as a string. This is useful for debugging complex types, such as objects.

--- a/pkg/reader/reader.go
+++ b/pkg/reader/reader.go
@@ -111,10 +111,10 @@ func getTranslatedVariableFromBlock(block *hcl.Block, file *hcl.File) (string, m
 		out.TypeAsString = &typeAsString
 	}
 
-	// if a validation block does not exist, variable.Validation is nil.
-	if variable.Validation != nil && variable.Validation.Condition != nil {
-		conditionAsString := printToString(variable.Validation.Condition, file)
-		out.ConditionAsString = &conditionAsString
+	// plaintext print all condition expressions into the ConditionsAsString field.
+	out.ConditionsAsString = make([]string, len(variable.Validations))
+	for i, validation := range variable.Validations {
+		out.ConditionsAsString[i] = printToString(validation.Condition, file)
 	}
 
 	return name, out, nil

--- a/test/expected/custom-validation/sample-input/test-input-all.json
+++ b/test/expected/custom-validation/sample-input/test-input-all.json
@@ -1,6 +1,9 @@
 {
     "$schema": "../schema.json",
-    "a_list_maximum_minimum_length": ["a", "b"],
+    "a_list_maximum_minimum_length": [
+        "a",
+        "b"
+    ],
     "a_map_maximum_minimum_entries": {
         "a": "a",
         "b": "b"
@@ -9,7 +12,10 @@
     "a_number_enum_kind_2": 2,
     "a_number_exclusive_maximum_minimum": 2,
     "a_number_maximum_minimum": 1,
-    "a_set_maximum_minimum_items": ["a", "b"],
+    "a_set_maximum_minimum_items": [
+        "a",
+        "b"
+    ],
     "a_string_enum_escaped_characters_kind_1": "${abc}",
     "a_string_enum_escaped_characters_kind_2": "\"",
     "a_string_enum_kind_1": "a",
@@ -23,5 +29,6 @@
         "name": "a",
         "other_name": "this is an additional property, terraform will ignore it"
     },
+    "a_string_multiple_validation_conditions": "abcd",
     "something_else": "string"
 }

--- a/test/expected/custom-validation/sample-input/test-input-bad.json
+++ b/test/expected/custom-validation/sample-input/test-input-bad.json
@@ -6,7 +6,18 @@
     "a_number_enum_kind_2": 5,
     "a_number_exclusive_maximum_minimum": 100,
     "a_number_maximum_minimum": 100,
-    "a_set_maximum_minimum_items": ["a", "a", "a", "a", "a", "a", "a", "a", "a", "a"],
+    "a_set_maximum_minimum_items": [
+        "a",
+        "a",
+        "a",
+        "a",
+        "a",
+        "a",
+        "a",
+        "a",
+        "a",
+        "a"
+    ],
     "a_string_enum_escaped_characters_kind_1": "\\\\",
     "a_string_enum_escaped_characters_kind_2": "\\t",
     "a_string_enum_kind_1": "d",
@@ -16,7 +27,8 @@
     "a_string_pattern_2": "#bcdefg",
     "an_object_maximum_minimum_items": {
         "name": false,
-        "number":1,
+        "number": 1,
         "large": false
-    }
+    },
+    "a_string_multiple_validation_conditions": "a"
 }

--- a/test/expected/custom-validation/sample-input/test-input-null.json
+++ b/test/expected/custom-validation/sample-input/test-input-null.json
@@ -16,5 +16,6 @@
     "a_string_pattern_1": null,
     "a_string_pattern_2": null,
     "a_string_set_length": null,
-    "an_object_maximum_minimum_items": null 
+    "an_object_maximum_minimum_items": null,
+    "a_string_multiple_validation_conditions": null
 }

--- a/test/expected/custom-validation/schema-disallow-additional.json
+++ b/test/expected/custom-validation/schema-disallow-additional.json
@@ -153,6 +153,13 @@
 			"minLength": 1,
 			"type": "string"
 		},
+		"a_string_multiple_validation_conditions": {
+			"default": "hello",
+			"description": "A string which has a minimum and maximum length, defined as 2 separate validation blocks",
+			"maxLength": 7,
+			"minLength": 2,
+			"type": "string"
+		},
 		"a_string_pattern_1": {
 			"default": "1.1.1.1",
 			"description": "A string variable that must be a valid IPv4 address",

--- a/test/expected/custom-validation/schema-nullable-all.json
+++ b/test/expected/custom-validation/schema-nullable-all.json
@@ -283,6 +283,23 @@
 			"minLength": 1,
 			"title": "a_string_maximum_minimum_length: Select a type"
 		},
+		"a_string_multiple_validation_conditions": {
+			"anyOf": [
+				{
+					"title": "null",
+					"type": "null"
+				},
+				{
+					"title": "string",
+					"type": "string"
+				}
+			],
+			"default": "hello",
+			"description": "A string which has a minimum and maximum length, defined as 2 separate validation blocks",
+			"maxLength": 7,
+			"minLength": 2,
+			"title": "a_string_multiple_validation_conditions: Select a type"
+		},
 		"a_string_pattern_1": {
 			"anyOf": [
 				{

--- a/test/expected/custom-validation/schema.json
+++ b/test/expected/custom-validation/schema.json
@@ -153,6 +153,13 @@
 			"minLength": 1,
 			"type": "string"
 		},
+		"a_string_multiple_validation_conditions": {
+			"default": "hello",
+			"description": "A string which has a minimum and maximum length, defined as 2 separate validation blocks",
+			"maxLength": 7,
+			"minLength": 2,
+			"type": "string"
+		},
 		"a_string_pattern_1": {
 			"default": "1.1.1.1",
 			"description": "A string variable that must be a valid IPv4 address",

--- a/test/expected/custom-validation/variables.json
+++ b/test/expected/custom-validation/variables.json
@@ -4,10 +4,12 @@
 			"a"
 		],
 		"description": "A list variable that must have a length greater than 0 and less than 10",
-		"validation": {
-			"condition": "length(var.a_list_maximum_minimum_length) > 0 && length(var.a_list_maximum_minimum_length) < 10",
-			"error_message": "a_list_maximum_minimum_length must have a length greater than 0 and less than 10"
-		},
+		"validation": [
+			{
+				"condition": "length(var.a_list_maximum_minimum_length) > 0 && length(var.a_list_maximum_minimum_length) < 10",
+				"error_message": "a_list_maximum_minimum_length must have a length greater than 0 and less than 10"
+			}
+		],
 		"type": [
 			"list",
 			"string"
@@ -18,10 +20,12 @@
 			"a": "a"
 		},
 		"description": "A map variable that must have greater than 0 and less than 10 entries",
-		"validation": {
-			"condition": "length(var.a_map_maximum_minimum_entries) > 0 &&  length(var.a_map_maximum_minimum_entries)< 10",
-			"error_message": "a_map_maximum_minimum_entries must greater than 0 and less than 10 entries"
-		},
+		"validation": [
+			{
+				"condition": "length(var.a_map_maximum_minimum_entries) > 0 &&  length(var.a_map_maximum_minimum_entries)< 10",
+				"error_message": "a_map_maximum_minimum_entries must greater than 0 and less than 10 entries"
+			}
+		],
 		"type": [
 			"map",
 			"string"
@@ -30,37 +34,45 @@
 	"a_number_enum_kind_1": {
 		"default": 1,
 		"description": "A number variable that must be one of the values 1, 2, or 3",
-		"validation": {
-			"condition": "contains([1, 2, 3], var.a_number_enum_kind_1)",
-			"error_message": "Invalid value for a_number_enum_kind_1"
-		},
+		"validation": [
+			{
+				"condition": "contains([1, 2, 3], var.a_number_enum_kind_1)",
+				"error_message": "Invalid value for a_number_enum_kind_1"
+			}
+		],
 		"type": "number"
 	},
 	"a_number_enum_kind_2": {
 		"default": 1,
 		"description": "A number variable that must be one of the values 1, 2, or 3",
-		"validation": {
-			"condition": "var.a_number_enum_kind_2 == 1 || var.a_number_enum_kind_2 == 2 || var.a_number_enum_kind_2 == 3",
-			"error_message": "Invalid value for a_number_enum_kind_2"
-		},
+		"validation": [
+			{
+				"condition": "var.a_number_enum_kind_2 == 1 || var.a_number_enum_kind_2 == 2 || var.a_number_enum_kind_2 == 3",
+				"error_message": "Invalid value for a_number_enum_kind_2"
+			}
+		],
 		"type": "number"
 	},
 	"a_number_exclusive_maximum_minimum": {
 		"default": 1,
 		"description": "A number variable that must be greater than 0 and less than 10",
-		"validation": {
-			"condition": "var.a_number_exclusive_maximum_minimum > 0 && var.a_number_exclusive_maximum_minimum < 10",
-			"error_message": "a_number_exclusive_maximum_minimum must be less than 10 and greater than 0"
-		},
+		"validation": [
+			{
+				"condition": "var.a_number_exclusive_maximum_minimum > 0 && var.a_number_exclusive_maximum_minimum < 10",
+				"error_message": "a_number_exclusive_maximum_minimum must be less than 10 and greater than 0"
+			}
+		],
 		"type": "number"
 	},
 	"a_number_maximum_minimum": {
 		"default": 0,
 		"description": "A number variable that must be between 0 and 10 (inclusive)",
-		"validation": {
-			"condition": "var.a_number_maximum_minimum >= 0 && var.a_number_maximum_minimum <= 10",
-			"error_message": "a_number_maximum_minimum must be less than or equal to 10 and greater than or equal to 0"
-		},
+		"validation": [
+			{
+				"condition": "var.a_number_maximum_minimum >= 0 && var.a_number_maximum_minimum <= 10",
+				"error_message": "a_number_maximum_minimum must be less than or equal to 10 and greater than or equal to 0"
+			}
+		],
 		"type": "number"
 	},
 	"a_set_maximum_minimum_items": {
@@ -68,10 +80,12 @@
 			"a"
 		],
 		"description": "A set variable that must have a length greater than 0 and less than 10",
-		"validation": {
-			"condition": "0 < length(var.a_set_maximum_minimum_items) && 10 > length(var.a_set_maximum_minimum_items)",
-			"error_message": "a_set_maximum_minimum_items must have a length greater than 0 and less than 10"
-		},
+		"validation": [
+			{
+				"condition": "0 < length(var.a_set_maximum_minimum_items) && 10 > length(var.a_set_maximum_minimum_items)",
+				"error_message": "a_set_maximum_minimum_items must have a length greater than 0 and less than 10"
+			}
+		],
 		"type": [
 			"set",
 			"string"
@@ -80,82 +94,119 @@
 	"a_string_enum_escaped_characters_kind_1": {
 		"default": "\\",
 		"description": "A string variable that must some complicated escaped characters",
-		"validation": {
-			"condition": "contains([\"\\\\\", \"\\\"\", \"\\\\\\\"\", \"$${abc}\",\"\\n\",\"\\t\",\"10%\",\"10%%\",\"$a\",\"$$a\",\"\\r\",\"\\\\r\", null, \"<\", \">\", \"&\"], var.a_string_enum_escaped_characters_kind_1)",
-			"error_message": "Invalid value for a_string_enum_escaped_characters"
-		},
+		"validation": [
+			{
+				"condition": "contains([\"\\\\\", \"\\\"\", \"\\\\\\\"\", \"$${abc}\",\"\\n\",\"\\t\",\"10%\",\"10%%\",\"$a\",\"$$a\",\"\\r\",\"\\\\r\", null, \"<\", \">\", \"&\"], var.a_string_enum_escaped_characters_kind_1)",
+				"error_message": "Invalid value for a_string_enum_escaped_characters"
+			}
+		],
 		"type": "string"
 	},
 	"a_string_enum_escaped_characters_kind_2": {
 		"default": "\"",
 		"description": "A string variable that must some complicated escaped characters",
-		"validation": {
-			"condition": "var.a_string_enum_escaped_characters_kind_2 == \"\\\\\" || var.a_string_enum_escaped_characters_kind_2 == \"\\\"\" || var.a_string_enum_escaped_characters_kind_2 == \"\\\\\\\"\" || var.a_string_enum_escaped_characters_kind_2 == \"$${abc}\" || var.a_string_enum_escaped_characters_kind_2 == \"\\n\" || var.a_string_enum_escaped_characters_kind_2 == \"\\t\" || var.a_string_enum_escaped_characters_kind_2 == \"10%\" || var.a_string_enum_escaped_characters_kind_2 == \"10%%\" || var.a_string_enum_escaped_characters_kind_2 == \"$a\" || var.a_string_enum_escaped_characters_kind_2 == \"$$a\" || var.a_string_enum_escaped_characters_kind_2 == \"\\r\" || var.a_string_enum_escaped_characters_kind_2 == \"\\\\r\" || var.a_string_enum_escaped_characters_kind_2 == null || var.a_string_enum_escaped_characters_kind_2 == \"<\" || var.a_string_enum_escaped_characters_kind_2 == \">\" || var.a_string_enum_escaped_characters_kind_2  == \"&\"",
-			"error_message": "Invalid value for a_string_enum_escaped_characters"
-		},
+		"validation": [
+			{
+				"condition": "var.a_string_enum_escaped_characters_kind_2 == \"\\\\\" || var.a_string_enum_escaped_characters_kind_2 == \"\\\"\" || var.a_string_enum_escaped_characters_kind_2 == \"\\\\\\\"\" || var.a_string_enum_escaped_characters_kind_2 == \"$${abc}\" || var.a_string_enum_escaped_characters_kind_2 == \"\\n\" || var.a_string_enum_escaped_characters_kind_2 == \"\\t\" || var.a_string_enum_escaped_characters_kind_2 == \"10%\" || var.a_string_enum_escaped_characters_kind_2 == \"10%%\" || var.a_string_enum_escaped_characters_kind_2 == \"$a\" || var.a_string_enum_escaped_characters_kind_2 == \"$$a\" || var.a_string_enum_escaped_characters_kind_2 == \"\\r\" || var.a_string_enum_escaped_characters_kind_2 == \"\\\\r\" || var.a_string_enum_escaped_characters_kind_2 == null || var.a_string_enum_escaped_characters_kind_2 == \"<\" || var.a_string_enum_escaped_characters_kind_2 == \">\" || var.a_string_enum_escaped_characters_kind_2  == \"&\"",
+				"error_message": "Invalid value for a_string_enum_escaped_characters"
+			}
+		],
 		"type": "string"
 	},
 	"a_string_enum_kind_1": {
 		"default": "a",
 		"description": "A string variable that must be one of the values 'a', 'b', or 'c'",
-		"validation": {
-			"condition": "contains([\"a\", \"b\", \"c\"], var.a_string_enum_kind_1)",
-			"error_message": "Invalid value for a_string_enum_kind_1"
-		},
+		"validation": [
+			{
+				"condition": "contains([\"a\", \"b\", \"c\"], var.a_string_enum_kind_1)",
+				"error_message": "Invalid value for a_string_enum_kind_1"
+			}
+		],
 		"type": "string"
 	},
 	"a_string_enum_kind_2": {
 		"default": "a",
 		"description": "A string variable that must be one of the values 'a', 'b', or 'c'",
-		"validation": {
-			"condition": "var.a_string_enum_kind_2 == \"a\" || var.a_string_enum_kind_2 == \"b\" || var.a_string_enum_kind_2 == \"c\"",
-			"error_message": "Invalid value for a_string_enum_kind_2"
-		},
+		"validation": [
+			{
+				"condition": "var.a_string_enum_kind_2 == \"a\" || var.a_string_enum_kind_2 == \"b\" || var.a_string_enum_kind_2 == \"c\"",
+				"error_message": "Invalid value for a_string_enum_kind_2"
+			}
+		],
 		"type": "string"
 	},
 	"a_string_length_over_defined": {
 		"default": "a",
 		"description": "A string variable that must have length 4",
-		"validation": {
-			"condition": "2<length(var.a_string_length_over_defined)&&length(var.a_string_length_over_defined) == 4&& 7>length(var.a_string_length_over_defined)",
-			"error_message": "a_string_set_length must have length 4"
-		},
+		"validation": [
+			{
+				"condition": "2<length(var.a_string_length_over_defined)&&length(var.a_string_length_over_defined) == 4&& 7>length(var.a_string_length_over_defined)",
+				"error_message": "a_string_set_length must have length 4"
+			}
+		],
 		"type": "string"
 	},
 	"a_string_maximum_minimum_length": {
 		"default": "a",
 		"description": "A string variable that must have a length less than 10 and greater than 0",
-		"validation": {
-			"condition": "0<length(var.a_string_maximum_minimum_length)&&length(var.a_string_maximum_minimum_length)<10",
-			"error_message": "a_string_maximum_minimum_length must have a length less than 10 and greater than 0"
-		},
+		"validation": [
+			{
+				"condition": "0<length(var.a_string_maximum_minimum_length)&&length(var.a_string_maximum_minimum_length)<10",
+				"error_message": "a_string_maximum_minimum_length must have a length less than 10 and greater than 0"
+			}
+		],
+		"type": "string"
+	},
+	"a_string_multiple_validation_conditions": {
+		"default": "hello",
+		"description": "A string which has a minimum and maximum length, defined as 2 separate validation blocks",
+		"validation": [
+			{
+				"condition": "length(var.a_string_multiple_validation_conditions) < 8",
+				"error_message": "Must be fewer than 8 characters"
+			},
+			{
+				"condition": "length(var.a_string_multiple_validation_conditions) >= 1",
+				"error_message": "Must have greater than or equal to 1 character (note: redundant check for test)"
+			},
+			{
+				"condition": "length(var.a_string_multiple_validation_conditions) >= 2",
+				"error_message": "Must have greater than or equal to 2 characters"
+			}
+		],
 		"type": "string"
 	},
 	"a_string_pattern_1": {
 		"default": "1.1.1.1",
 		"description": "A string variable that must be a valid IPv4 address",
-		"validation": {
-			"condition": "can( regex( \"^[0-9]{1,3}(\\\\.[0-9]{1,3}){3}$\" , var.a_string_pattern_1 ) )",
-			"error_message": "a_string_pattern_1 must be an IPv4 address"
-		},
+		"validation": [
+			{
+				"condition": "can( regex( \"^[0-9]{1,3}(\\\\.[0-9]{1,3}){3}$\" , var.a_string_pattern_1 ) )",
+				"error_message": "a_string_pattern_1 must be an IPv4 address"
+			}
+		],
 		"type": "string"
 	},
 	"a_string_pattern_2": {
 		"default": "#000000",
 		"description": "string that must be a valid colour hex code in the form #RRGGBB",
-		"validation": {
-			"condition": "can(regex(\"^#[0-9a-fA-F]{6}$\",var.a_string_pattern_2))",
-			"error_message": "a_string_pattern_2 must be a valid colour hex code in the form #RRGGBB"
-		},
+		"validation": [
+			{
+				"condition": "can(regex(\"^#[0-9a-fA-F]{6}$\",var.a_string_pattern_2))",
+				"error_message": "a_string_pattern_2 must be a valid colour hex code in the form #RRGGBB"
+			}
+		],
 		"type": "string"
 	},
 	"a_string_set_length": {
 		"default": "abcd",
 		"description": "A string variable that must have length 4",
-		"validation": {
-			"condition": "4==length(var.a_string_set_length)",
-			"error_message": "a_string_set_length must have length 4"
-		},
+		"validation": [
+			{
+				"condition": "4==length(var.a_string_set_length)",
+				"error_message": "a_string_set_length must have length 4"
+			}
+		],
 		"type": "string"
 	},
 	"an_object_maximum_minimum_items": {
@@ -164,10 +215,12 @@
 			"other_field": "b"
 		},
 		"description": "An object variable that must have fewer than 3 properties",
-		"validation": {
-			"condition": "length(var.an_object_maximum_minimum_items) > 0 && length(var.an_object_maximum_minimum_items) < 3",
-			"error_message": "an_object_maximum_minimum_items must have fewer than 3 properties"
-		},
+		"validation": [
+			{
+				"condition": "length(var.an_object_maximum_minimum_items) > 0 && length(var.an_object_maximum_minimum_items) < 3",
+				"error_message": "an_object_maximum_minimum_items must have fewer than 3 properties"
+			}
+		],
 		"type": [
 			"object",
 			{

--- a/test/modules/custom-validation/variables.tf
+++ b/test/modules/custom-validation/variables.tf
@@ -178,3 +178,21 @@ variable "a_string_enum_escaped_characters_kind_2" {
   }
   default = "\""
 }
+
+variable "a_string_multiple_validation_conditions" {
+  type = string
+  description = "A string which has a minimum and maximum length, defined as 2 separate validation blocks"
+  validation {
+    condition = length(var.a_string_multiple_validation_conditions) < 8
+    error_message = "Must be fewer than 8 characters"
+  }
+  validation {
+    condition = length(var.a_string_multiple_validation_conditions) >= 1
+    error_message = "Must have greater than or equal to 1 character (note: redundant check for test)"
+  }
+  validation {
+    condition = length(var.a_string_multiple_validation_conditions) >= 2
+    error_message = "Must have greater than or equal to 2 characters"
+  }
+  default = "hello"
+}


### PR DESCRIPTION
This was missing from the original design because I was unaware that
Terraform allows this. It was pretty straightforward to add though, I
just needed to change the internal `Validation` field to be a slice and
then apply each condition from the slice to the variable.

Mixing and matching rules has not been
tested extensively but hopefully all the JSON schema fields should play
nicely together.

In particular, it is already the case that if multiple
rules specify a minimum or maximum value, then only the "lowest maximum"
and "highest minimum" values are considered, as would be expected.

Certain other fields will not work if used multiple times, such as
`pattern` (regex). Whichever regex is specified last will take
precedence.

Because of edge cases like this, multiple validation rules should be
used with caution.

Closes #28 