### PR TITLE
feat: add `schema-id` option to generate the schema with a custom ID

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,6 +80,8 @@ running Terraform.
 
 - `--ignore-variable=<VAR_NAME>`: Ignore a variable with the name `VAR_NAME` in the schema. This can be used to exclude variables which are not intended to be used in the schema, such as those which are only used in the module itself. This flag can be used multiple times to ignore multiple variables.
 
+- `--schema-id=<ID>`: Set the `$id` field in the schema to `ID`. This can be used to set a unique identifier for the schema. By default, this field is not set. For more  information see https://json-schema.org/understanding-json-schema/basics#declaring-a-unique-identifier.
+
 # Design
 
 ### Parsing Terraform Configuration Files

--- a/cmd/cmd.go
+++ b/cmd/cmd.go
@@ -28,6 +28,7 @@ var (
 	exportVariables              bool
 	escapeJSON                   bool
 	ignoreVariables              []string
+	schemaID                     string
 )
 
 // rootCmd is the base command for terraschema
@@ -109,6 +110,9 @@ func init() {
 	rootCmd.Flags().StringSliceVar(&ignoreVariables, "ignore-variable", []string{},
 		"ignore a variable by name when generating schema or exporting variables,\n"+
 			"repeating this argument allows you to ignore multiple variables",
+	)
+	rootCmd.Flags().StringVar(&schemaID, "schema-id", "",
+		"set the $id field in the JSON Schema to a custom value",
 	)
 
 	rootCmd.SetFlagErrorFunc(func(cmd *cobra.Command, err error) error {

--- a/pkg/jsonschema/json-schema.go
+++ b/pkg/jsonschema/json-schema.go
@@ -18,6 +18,7 @@ type CreateSchemaOptions struct {
 	SuppressLogging           bool
 	NullableAll               bool
 	IgnoreVariables           []string
+	SchemaID                  string
 }
 
 func CreateSchema(path string, options CreateSchemaOptions) (map[string]any, error) {
@@ -39,6 +40,10 @@ func CreateSchema(path string, options CreateSchemaOptions) (map[string]any, err
 	schemaOut["$schema"] = "http://json-schema.org/draft-07/schema#"
 	schemaOut["type"] = "object"
 	schemaOut["additionalProperties"] = options.AllowAdditionalProperties
+
+	if options.SchemaID != "" {
+		schemaOut["$id"] = options.SchemaID
+	}
 
 	properties := make(map[string]any)
 	requiredArray := []any{}

--- a/pkg/jsonschema/json-schema_test.go
+++ b/pkg/jsonschema/json-schema_test.go
@@ -53,6 +53,41 @@ func TestCreateSchema(t *testing.T) {
 	}
 }
 
+func TestCreateSchemaID(t *testing.T) {
+	t.Parallel()
+	tfPath := "../../test/modules"
+	schemaPath := "../../test/expected"
+	testCases := []string{
+		"custom-id",
+	}
+	for i := range testCases {
+		name := testCases[i]
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+			expected, err := os.ReadFile(filepath.Join(schemaPath, name, "schema.json"))
+			require.NoError(t, err)
+
+			result, err := CreateSchema(filepath.Join(tfPath, name), CreateSchemaOptions{
+				RequireAll:                false,
+				AllowAdditionalProperties: true,
+				AllowEmpty:                true,
+				NullableAll:               false,
+				IgnoreVariables:           []string{},
+				SchemaID:                  "https://github.com/HewlettPackard/terraschema/schema.json",
+			})
+			require.NoError(t, err)
+
+			var expectedMap map[string]any
+			err = json.Unmarshal(expected, &expectedMap)
+			require.NoError(t, err)
+
+			if d := cmp.Diff(expectedMap, result); d != "" {
+				t.Errorf("Schema has incorrect value (-want,+got):\n%s", d)
+			}
+		})
+	}
+}
+
 type errorLocation struct {
 	name            string
 	nestedLocations []errorLocation

--- a/test/expected/custom-id/schema.json
+++ b/test/expected/custom-id/schema.json
@@ -1,0 +1,20 @@
+{
+	"$schema": "http://json-schema.org/draft-07/schema#",
+	"$id": "https://github.com/HewlettPackard/terraschema/schema.json",
+	"additionalProperties": true,
+	"properties": {
+		"age": {
+			"description": "Your age. Required.",
+			"type": "number"
+		},
+		"name": {
+			"default": "world",
+			"description": "Your name.",
+			"type": "string"
+		}
+	},
+	"required": [
+		"age"
+	],
+	"type": "object"
+}

--- a/test/modules/custom-id/variables.tf
+++ b/test/modules/custom-id/variables.tf
@@ -1,0 +1,12 @@
+# Copyright 2024 Hewlett Packard Enterprise Development LP
+
+variable "name" {
+    type        = string
+    description = "Your name."
+    default = "world"
+}
+
+variable "age" {
+    type        = number
+    description = "Your age. Required."
+}


### PR DESCRIPTION
This pull request adds a way to customize the generated schema with a custom ID.

The current behavior is not changed, no ID is generated by default.