### PR TITLE
feat: add `property` flag to generate property on root object schema

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,6 +80,8 @@ running Terraform.
 
 - `--ignore-variable=<VAR_NAME>`: Ignore a variable with the name `VAR_NAME` in the schema. This can be used to exclude variables which are not intended to be used in the schema, such as those which are only used in the module itself. This flag can be used multiple times to ignore multiple variables.
 
+- `--property=<KEY>=<VALUE>`: Add a property to the root object of the schema. This can be used to add metadata to the schema, such as `$id` or `title`. This flag can be used multiple times to add multiple properties.
+
 # Design
 
 ### Parsing Terraform Configuration Files

--- a/cmd/cmd.go
+++ b/cmd/cmd.go
@@ -28,6 +28,7 @@ var (
 	exportVariables              bool
 	escapeJSON                   bool
 	ignoreVariables              []string
+	customProperties             []string
 )
 
 // rootCmd is the base command for terraschema
@@ -109,6 +110,9 @@ func init() {
 	rootCmd.Flags().StringSliceVar(&ignoreVariables, "ignore-variable", []string{},
 		"ignore a variable by name when generating schema or exporting variables,\n"+
 			"repeating this argument allows you to ignore multiple variables",
+	)
+	rootCmd.Flags().StringSliceVar(&customProperties, "property", []string{},
+		"add a property to the JSON Schema, in the format 'key=value'",
 	)
 
 	rootCmd.SetFlagErrorFunc(func(cmd *cobra.Command, err error) error {
@@ -202,6 +206,7 @@ func runCommand(cmd *cobra.Command, args []string) error {
 			SuppressLogging:           outputStdOut,
 			NullableAll:               nullableAll,
 			IgnoreVariables:           ignoreVariables,
+			CustomProperties:          parseProperties(),
 		})
 		if err != nil {
 			return fmt.Errorf("error creating schema: %w", err)
@@ -240,4 +245,20 @@ func runCommand(cmd *cobra.Command, args []string) error {
 	fmt.Printf("Info: schema written to %q\n", outputPath)
 
 	return nil
+}
+
+func parseProperties() map[string]string {
+	properties := make(map[string]string)
+	for _, prop := range customProperties {
+		keyVal := strings.SplitN(prop, "=", 2)
+		if len(keyVal) != 2 {
+			fmt.Printf("Warning: invalid property %q, skipping\n", prop)
+
+			continue
+		}
+
+		properties[keyVal[0]] = keyVal[1]
+	}
+
+	return properties
 }

--- a/pkg/jsonschema/json-schema.go
+++ b/pkg/jsonschema/json-schema.go
@@ -18,6 +18,7 @@ type CreateSchemaOptions struct {
 	SuppressLogging           bool
 	NullableAll               bool
 	IgnoreVariables           []string
+	CustomProperties          map[string]string
 }
 
 func CreateSchema(path string, options CreateSchemaOptions) (map[string]any, error) {
@@ -64,6 +65,11 @@ func CreateSchema(path string, options CreateSchemaOptions) (map[string]any, err
 
 	slices.SortFunc(requiredArray, sortInterfaceAlphabetical) // get required in alphabetical order
 	schemaOut["required"] = requiredArray
+
+	// Add  the custom properties in last to allow overriding the default properties.
+	for key, value := range options.CustomProperties {
+		schemaOut[key] = value
+	}
 
 	return schemaOut, nil
 }

--- a/pkg/jsonschema/json-schema_test.go
+++ b/pkg/jsonschema/json-schema_test.go
@@ -53,6 +53,44 @@ func TestCreateSchema(t *testing.T) {
 	}
 }
 
+func TestCreateSchemaWithCustomProperties(t *testing.T) {
+	t.Parallel()
+	tfPath := "../../test/modules"
+	schemaPath := "../../test/expected"
+	testCases := []string{
+		"custom-properties",
+	}
+	for i := range testCases {
+		name := testCases[i]
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+			expected, err := os.ReadFile(filepath.Join(schemaPath, name, "schema.json"))
+			require.NoError(t, err)
+
+			result, err := CreateSchema(filepath.Join(tfPath, name), CreateSchemaOptions{
+				RequireAll:                false,
+				AllowAdditionalProperties: true,
+				AllowEmpty:                true,
+				NullableAll:               false,
+				IgnoreVariables:           []string{},
+				CustomProperties: map[string]string{
+					"$id":   "http://example.com/schema",
+					"title": "Example Schema",
+				},
+			})
+			require.NoError(t, err)
+
+			var expectedMap map[string]any
+			err = json.Unmarshal(expected, &expectedMap)
+			require.NoError(t, err)
+
+			if d := cmp.Diff(expectedMap, result); d != "" {
+				t.Errorf("Schema has incorrect value (-want,+got):\n%s", d)
+			}
+		})
+	}
+}
+
 type errorLocation struct {
 	name            string
 	nestedLocations []errorLocation

--- a/test/expected/custom-properties/schema.json
+++ b/test/expected/custom-properties/schema.json
@@ -1,0 +1,21 @@
+{
+	"$schema": "http://json-schema.org/draft-07/schema#",
+	"$id": "http://example.com/schema",
+	"title": "Example Schema",
+	"additionalProperties": true,
+	"properties": {
+		"age": {
+			"description": "Your age. Required.",
+			"type": "number"
+		},
+		"name": {
+			"default": "world",
+			"description": "Your name.",
+			"type": "string"
+		}
+	},
+	"required": [
+		"age"
+	],
+	"type": "object"
+}

--- a/test/modules/custom-properties/variables.tf
+++ b/test/modules/custom-properties/variables.tf
@@ -1,0 +1,12 @@
+# Copyright 2024 Hewlett Packard Enterprise Development LP
+
+variable "name" {
+    type        = string
+    description = "Your name."
+    default = "world"
+}
+
+variable "age" {
+    type        = number
+    description = "Your age. Required."
+}


### PR DESCRIPTION
This allows you to generate any property on the root schema object.

This does not alter the current behavior if left unspecified (default).