### PR TITLE
feat: Exit with non-zero code on errors

### DIFF
--- a/main.go
+++ b/main.go
@@ -2,9 +2,15 @@
 package main
 
 import (
+	"fmt"
+	"os"
+
 	"github.com/HewlettPackard/terraschema/cmd"
 )
 
 func main() {
-	_ = cmd.Execute()
+	if err := cmd.Execute(); err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		os.Exit(1)
+	}
 }


### PR DESCRIPTION
Fixes #53.

This change updates the exit logic so that terraschema will now exit with code 1 when an error occurs.
Implementation was based on the example from the [Cobra user guide](https://github.com/spf13/cobra/blob/main/site/content/user_guide.md#create-rootcmd).

⚠️ Breaking Change Notice
Previously, terraschema always exited with code 0, even on errors.
As a result, CI pipelines or scripts that relied on ignoring errors may be affected by this update.

If you need to support backward compability, I can add an option to preserve the old behavior (defaulting to exit code 0) and require an explicit flag to enable non-zero exit codes.

However, this is not recommended pattern, processes should exit with a non-zero status when they fail to perform their intended task ([reference](https://en.wikipedia.org/wiki/Exit_status)).