### PR TITLE
fix: Update nullable variable handling as 'anyOf' to 'oneOf'

### DIFF
--- a/pkg/jsonschema/type.go
+++ b/pkg/jsonschema/type.go
@@ -110,7 +110,7 @@ func getNullableNode(name string, typeInterface any, options CreateSchemaOptions
 
 	internalNode["title"] = title
 
-	node["anyOf"] = []any{
+	node["oneOf"] = []any{
 		map[string]any{"type": "null", "title": "null"},
 		internalNode,
 	}

--- a/test/expected/complex-types/schema-nullable-all.json
+++ b/test/expected/complex-types/schema-nullable-all.json
@@ -3,7 +3,55 @@
 	"additionalProperties": true,
 	"properties": {
 		"a_very_complicated_object": {
-			"anyOf": [
+			"default": {
+				"b": [
+					[
+						"a",
+						"b",
+						"c"
+					],
+					true
+				],
+				"c": {
+					"a": [
+						"a"
+					],
+					"b": [
+						"b"
+					]
+				},
+				"d": {
+					"a": [
+						[
+							"a",
+							"b"
+						],
+						[
+							"c",
+							"d"
+						]
+					],
+					"b": 1
+				},
+				"e": [
+					"a",
+					1
+				],
+				"f": [
+					[
+						"a"
+					],
+					[
+						"b"
+					],
+					[
+						"a",
+						"b"
+					]
+				]
+			},
+			"description": "This is a very complicated object",
+			"oneOf": [
 				{
 					"title": "null",
 					"type": "null"
@@ -96,58 +144,16 @@
 					"type": "object"
 				}
 			],
-			"default": {
-				"b": [
-					[
-						"a",
-						"b",
-						"c"
-					],
-					true
-				],
-				"c": {
-					"a": [
-						"a"
-					],
-					"b": [
-						"b"
-					]
-				},
-				"d": {
-					"a": [
-						[
-							"a",
-							"b"
-						],
-						[
-							"c",
-							"d"
-						]
-					],
-					"b": 1
-				},
-				"e": [
-					"a",
-					1
-				],
-				"f": [
-					[
-						"a"
-					],
-					[
-						"b"
-					],
-					[
-						"a",
-						"b"
-					]
-				]
-			},
-			"description": "This is a very complicated object",
 			"title": "a_very_complicated_object: Select a type"
 		},
 		"an_object_with_optional": {
-			"anyOf": [
+			"default": {
+				"a": "a",
+				"b": 1,
+				"c": true
+			},
+			"description": "This is an object variable with an optional field",
+			"oneOf": [
 				{
 					"title": "null",
 					"type": "null"
@@ -177,12 +183,6 @@
 					"type": "object"
 				}
 			],
-			"default": {
-				"a": "a",
-				"b": 1,
-				"c": true
-			},
-			"description": "This is an object variable with an optional field",
 			"title": "an_object_with_optional: Select a type"
 		}
 	},

--- a/test/expected/custom-validation/schema-nullable-all.json
+++ b/test/expected/custom-validation/schema-nullable-all.json
@@ -3,7 +3,9 @@
 	"additionalProperties": true,
 	"properties": {
 		"a_complex_condition_with_complex_error_message": {
-			"anyOf": [
+			"default": [],
+			"description": "A list of names that must be 3-24 lowercase letters and numbers.",
+			"oneOf": [
 				{
 					"title": "null",
 					"type": "null"
@@ -16,34 +18,38 @@
 					"type": "array"
 				}
 			],
-			"default": [],
-			"description": "A list of names that must be 3-24 lowercase letters and numbers.",
 			"title": "a_complex_condition_with_complex_error_message: Select a type"
 		},
 		"a_list_maximum_minimum_length": {
-			"anyOf": [
-				{
-					"title": "null",
-					"type": "null"
-				},
-				{
-					"items": {
-						"type": "string"
-					},
-					"title": "array",
-					"type": "array"
-				}
-			],
 			"default": [
 				"a"
 			],
 			"description": "A list variable that must have a length greater than 0 and less than 10",
 			"maxItems": 9,
 			"minItems": 1,
+			"oneOf": [
+				{
+					"title": "null",
+					"type": "null"
+				},
+				{
+					"items": {
+						"type": "string"
+					},
+					"title": "array",
+					"type": "array"
+				}
+			],
 			"title": "a_list_maximum_minimum_length: Select a type"
 		},
 		"a_map_maximum_minimum_entries": {
-			"anyOf": [
+			"default": {
+				"a": "a"
+			},
+			"description": "A map variable that must have greater than 0 and less than 10 entries",
+			"maxProperties": 9,
+			"minProperties": 1,
+			"oneOf": [
 				{
 					"title": "null",
 					"type": "null"
@@ -56,16 +62,17 @@
 					"type": "object"
 				}
 			],
-			"default": {
-				"a": "a"
-			},
-			"description": "A map variable that must have greater than 0 and less than 10 entries",
-			"maxProperties": 9,
-			"minProperties": 1,
 			"title": "a_map_maximum_minimum_entries: Select a type"
 		},
 		"a_number_enum_kind_1": {
-			"anyOf": [
+			"default": 1,
+			"description": "A number variable that must be one of the values 1, 2, or 3",
+			"enum": [
+				1,
+				2,
+				3
+			],
+			"oneOf": [
 				{
 					"title": "null",
 					"type": "null"
@@ -74,27 +81,10 @@
 					"title": "number",
 					"type": "number"
 				}
-			],
-			"default": 1,
-			"description": "A number variable that must be one of the values 1, 2, or 3",
-			"enum": [
-				1,
-				2,
-				3
 			],
 			"title": "a_number_enum_kind_1: Select a type"
 		},
 		"a_number_enum_kind_2": {
-			"anyOf": [
-				{
-					"title": "null",
-					"type": "null"
-				},
-				{
-					"title": "number",
-					"type": "number"
-				}
-			],
 			"default": 1,
 			"description": "A number variable that must be one of the values 1, 2, or 3",
 			"enum": [
@@ -102,10 +92,7 @@
 				2,
 				3
 			],
-			"title": "a_number_enum_kind_2: Select a type"
-		},
-		"a_number_exclusive_maximum_minimum": {
-			"anyOf": [
+			"oneOf": [
 				{
 					"title": "null",
 					"type": "null"
@@ -115,14 +102,14 @@
 					"type": "number"
 				}
 			],
+			"title": "a_number_enum_kind_2: Select a type"
+		},
+		"a_number_exclusive_maximum_minimum": {
 			"default": 1,
 			"description": "A number variable that must be greater than 0 and less than 10",
 			"exclusiveMaximum": 10,
 			"exclusiveMinimum": 0,
-			"title": "a_number_exclusive_maximum_minimum: Select a type"
-		},
-		"a_number_maximum_minimum": {
-			"anyOf": [
+			"oneOf": [
 				{
 					"title": "null",
 					"type": "null"
@@ -132,14 +119,33 @@
 					"type": "number"
 				}
 			],
+			"title": "a_number_exclusive_maximum_minimum: Select a type"
+		},
+		"a_number_maximum_minimum": {
 			"default": 0,
 			"description": "A number variable that must be between 0 and 10 (inclusive)",
 			"maximum": 10,
 			"minimum": 0,
+			"oneOf": [
+				{
+					"title": "null",
+					"type": "null"
+				},
+				{
+					"title": "number",
+					"type": "number"
+				}
+			],
 			"title": "a_number_maximum_minimum: Select a type"
 		},
 		"a_set_maximum_minimum_items": {
-			"anyOf": [
+			"default": [
+				"a"
+			],
+			"description": "A set variable that must have a length greater than 0 and less than 10",
+			"maxItems": 9,
+			"minItems": 1,
+			"oneOf": [
 				{
 					"title": "null",
 					"type": "null"
@@ -153,25 +159,9 @@
 					"uniqueItems": true
 				}
 			],
-			"default": [
-				"a"
-			],
-			"description": "A set variable that must have a length greater than 0 and less than 10",
-			"maxItems": 9,
-			"minItems": 1,
 			"title": "a_set_maximum_minimum_items: Select a type"
 		},
 		"a_string_enum_escaped_characters_kind_1": {
-			"anyOf": [
-				{
-					"title": "null",
-					"type": "null"
-				},
-				{
-					"title": "string",
-					"type": "string"
-				}
-			],
 			"default": "\\",
 			"description": "A string variable that must some complicated escaped characters",
 			"enum": [
@@ -192,10 +182,7 @@
 				">",
 				"&"
 			],
-			"title": "a_string_enum_escaped_characters_kind_1: Select a type"
-		},
-		"a_string_enum_escaped_characters_kind_2": {
-			"anyOf": [
+			"oneOf": [
 				{
 					"title": "null",
 					"type": "null"
@@ -205,6 +192,9 @@
 					"type": "string"
 				}
 			],
+			"title": "a_string_enum_escaped_characters_kind_1: Select a type"
+		},
+		"a_string_enum_escaped_characters_kind_2": {
 			"default": "\"",
 			"description": "A string variable that must some complicated escaped characters",
 			"enum": [
@@ -225,10 +215,7 @@
 				">",
 				"&"
 			],
-			"title": "a_string_enum_escaped_characters_kind_2: Select a type"
-		},
-		"a_string_enum_kind_1": {
-			"anyOf": [
+			"oneOf": [
 				{
 					"title": "null",
 					"type": "null"
@@ -238,26 +225,29 @@
 					"type": "string"
 				}
 			],
+			"title": "a_string_enum_escaped_characters_kind_2: Select a type"
+		},
+		"a_string_enum_kind_1": {
 			"default": "a",
 			"description": "A string variable that must be one of the values 'a', 'b', or 'c'",
 			"enum": [
 				"a",
 				"b",
 				"c"
+			],
+			"oneOf": [
+				{
+					"title": "null",
+					"type": "null"
+				},
+				{
+					"title": "string",
+					"type": "string"
+				}
 			],
 			"title": "a_string_enum_kind_1: Select a type"
 		},
 		"a_string_enum_kind_2": {
-			"anyOf": [
-				{
-					"title": "null",
-					"type": "null"
-				},
-				{
-					"title": "string",
-					"type": "string"
-				}
-			],
 			"default": "a",
 			"description": "A string variable that must be one of the values 'a', 'b', or 'c'",
 			"enum": [
@@ -265,10 +255,7 @@
 				"b",
 				"c"
 			],
-			"title": "a_string_enum_kind_2: Select a type"
-		},
-		"a_string_length_over_defined": {
-			"anyOf": [
+			"oneOf": [
 				{
 					"title": "null",
 					"type": "null"
@@ -278,14 +265,14 @@
 					"type": "string"
 				}
 			],
+			"title": "a_string_enum_kind_2: Select a type"
+		},
+		"a_string_length_over_defined": {
 			"default": "a",
 			"description": "A string variable that must have length 4",
 			"maxLength": 4,
 			"minLength": 4,
-			"title": "a_string_length_over_defined: Select a type"
-		},
-		"a_string_maximum_minimum_length": {
-			"anyOf": [
+			"oneOf": [
 				{
 					"title": "null",
 					"type": "null"
@@ -295,14 +282,14 @@
 					"type": "string"
 				}
 			],
+			"title": "a_string_length_over_defined: Select a type"
+		},
+		"a_string_maximum_minimum_length": {
 			"default": "a",
 			"description": "A string variable that must have a length less than 10 and greater than 0",
 			"maxLength": 9,
 			"minLength": 1,
-			"title": "a_string_maximum_minimum_length: Select a type"
-		},
-		"a_string_multiple_validation_conditions": {
-			"anyOf": [
+			"oneOf": [
 				{
 					"title": "null",
 					"type": "null"
@@ -312,14 +299,14 @@
 					"type": "string"
 				}
 			],
+			"title": "a_string_maximum_minimum_length: Select a type"
+		},
+		"a_string_multiple_validation_conditions": {
 			"default": "hello",
 			"description": "A string which has a minimum and maximum length, defined as 2 separate validation blocks",
 			"maxLength": 7,
 			"minLength": 2,
-			"title": "a_string_multiple_validation_conditions: Select a type"
-		},
-		"a_string_pattern_1": {
-			"anyOf": [
+			"oneOf": [
 				{
 					"title": "null",
 					"type": "null"
@@ -329,13 +316,28 @@
 					"type": "string"
 				}
 			],
+			"title": "a_string_multiple_validation_conditions: Select a type"
+		},
+		"a_string_pattern_1": {
 			"default": "1.1.1.1",
 			"description": "A string variable that must be a valid IPv4 address",
+			"oneOf": [
+				{
+					"title": "null",
+					"type": "null"
+				},
+				{
+					"title": "string",
+					"type": "string"
+				}
+			],
 			"pattern": "^[0-9]{1,3}(\\.[0-9]{1,3}){3}$",
 			"title": "a_string_pattern_1: Select a type"
 		},
 		"a_string_pattern_2": {
-			"anyOf": [
+			"default": "#000000",
+			"description": "string that must be a valid colour hex code in the form #RRGGBB",
+			"oneOf": [
 				{
 					"title": "null",
 					"type": "null"
@@ -345,13 +347,15 @@
 					"type": "string"
 				}
 			],
-			"default": "#000000",
-			"description": "string that must be a valid colour hex code in the form #RRGGBB",
 			"pattern": "^#[0-9a-fA-F]{6}$",
 			"title": "a_string_pattern_2: Select a type"
 		},
 		"a_string_set_length": {
-			"anyOf": [
+			"default": "abcd",
+			"description": "A string variable that must have length 4",
+			"maxLength": 4,
+			"minLength": 4,
+			"oneOf": [
 				{
 					"title": "null",
 					"type": "null"
@@ -361,14 +365,17 @@
 					"type": "string"
 				}
 			],
-			"default": "abcd",
-			"description": "A string variable that must have length 4",
-			"maxLength": 4,
-			"minLength": 4,
 			"title": "a_string_set_length: Select a type"
 		},
 		"an_object_maximum_minimum_items": {
-			"anyOf": [
+			"default": {
+				"name": "a",
+				"other_field": "b"
+			},
+			"description": "An object variable that must have fewer than 3 properties",
+			"maxProperties": 2,
+			"minProperties": 1,
+			"oneOf": [
 				{
 					"title": "null",
 					"type": "null"
@@ -387,13 +394,6 @@
 					"type": "object"
 				}
 			],
-			"default": {
-				"name": "a",
-				"other_field": "b"
-			},
-			"description": "An object variable that must have fewer than 3 properties",
-			"maxProperties": 2,
-			"minProperties": 1,
 			"title": "an_object_maximum_minimum_items: Select a type"
 		}
 	},

--- a/test/expected/simple-types/schema-disallow-additional.json
+++ b/test/expected/simple-types/schema-disallow-additional.json
@@ -108,7 +108,8 @@
 			"type": "object"
 		},
 		"a_nullable_string": {
-			"anyOf": [
+			"description": "This is a nullable string",
+			"oneOf": [
 				{
 					"title": "null",
 					"type": "null"
@@ -118,7 +119,6 @@
 					"type": "string"
 				}
 			],
-			"description": "This is a nullable string",
 			"title": "a_nullable_string: Select a type"
 		},
 		"a_number": {

--- a/test/expected/simple-types/schema-nullable-all.json
+++ b/test/expected/simple-types/schema-nullable-all.json
@@ -3,7 +3,9 @@
 	"additionalProperties": true,
 	"properties": {
 		"a_bool": {
-			"anyOf": [
+			"default": false,
+			"description": "This is a boolean",
+			"oneOf": [
 				{
 					"title": "null",
 					"type": "null"
@@ -13,34 +15,38 @@
 					"type": "boolean"
 				}
 			],
-			"default": false,
-			"description": "This is a boolean",
 			"title": "a_bool: Select a type"
 		},
 		"a_list": {
-			"anyOf": [
-				{
-					"title": "null",
-					"type": "null"
-				},
-				{
-					"items": {
-						"type": "string"
-					},
-					"title": "array",
-					"type": "array"
-				}
-			],
 			"default": [
 				"a",
 				"b",
 				"c"
 			],
 			"description": "This is a list of strings",
+			"oneOf": [
+				{
+					"title": "null",
+					"type": "null"
+				},
+				{
+					"items": {
+						"type": "string"
+					},
+					"title": "array",
+					"type": "array"
+				}
+			],
 			"title": "a_list: Select a type"
 		},
 		"a_list_of_any": {
-			"anyOf": [
+			"default": [
+				"a",
+				"b",
+				"c"
+			],
+			"description": "This is a list of any",
+			"oneOf": [
 				{
 					"title": "null",
 					"type": "null"
@@ -79,16 +85,16 @@
 					"type": "array"
 				}
 			],
-			"default": [
-				"a",
-				"b",
-				"c"
-			],
-			"description": "This is a list of any",
 			"title": "a_list_of_any: Select a type"
 		},
 		"a_map_of_any": {
-			"anyOf": [
+			"default": {
+				"a": "a",
+				"b": "b",
+				"c": "c"
+			},
+			"description": "This is a map of any",
+			"oneOf": [
 				{
 					"title": "null",
 					"type": "null"
@@ -127,16 +133,16 @@
 					"type": "object"
 				}
 			],
+			"title": "a_map_of_any: Select a type"
+		},
+		"a_map_of_strings": {
 			"default": {
 				"a": "a",
 				"b": "b",
 				"c": "c"
 			},
-			"description": "This is a map of any",
-			"title": "a_map_of_any: Select a type"
-		},
-		"a_map_of_strings": {
-			"anyOf": [
+			"description": "This is a map of strings",
+			"oneOf": [
 				{
 					"title": "null",
 					"type": "null"
@@ -149,16 +155,11 @@
 					"type": "object"
 				}
 			],
-			"default": {
-				"a": "a",
-				"b": "b",
-				"c": "c"
-			},
-			"description": "This is a map of strings",
 			"title": "a_map_of_strings: Select a type"
 		},
 		"a_nullable_string": {
-			"anyOf": [
+			"description": "This is a nullable string",
+			"oneOf": [
 				{
 					"title": "null",
 					"type": "null"
@@ -168,11 +169,11 @@
 					"type": "string"
 				}
 			],
-			"description": "This is a nullable string",
 			"title": "a_nullable_string: Select a type"
 		},
 		"a_number": {
-			"anyOf": [
+			"description": "This is a number",
+			"oneOf": [
 				{
 					"title": "null",
 					"type": "null"
@@ -182,11 +183,16 @@
 					"type": "number"
 				}
 			],
-			"description": "This is a number",
 			"title": "a_number: Select a type"
 		},
 		"a_set": {
-			"anyOf": [
+			"default": [
+				"a",
+				"b",
+				"c"
+			],
+			"description": "This is a set of strings",
+			"oneOf": [
 				{
 					"title": "null",
 					"type": "null"
@@ -200,16 +206,16 @@
 					"uniqueItems": true
 				}
 			],
+			"title": "a_set: Select a type"
+		},
+		"a_set_of_any": {
 			"default": [
 				"a",
 				"b",
 				"c"
 			],
-			"description": "This is a set of strings",
-			"title": "a_set: Select a type"
-		},
-		"a_set_of_any": {
-			"anyOf": [
+			"description": "This is a set of any",
+			"oneOf": [
 				{
 					"title": "null",
 					"type": "null"
@@ -249,16 +255,12 @@
 					"uniqueItems": true
 				}
 			],
-			"default": [
-				"a",
-				"b",
-				"c"
-			],
-			"description": "This is a set of any",
 			"title": "a_set_of_any: Select a type"
 		},
 		"a_string": {
-			"anyOf": [
+			"default": "a string",
+			"description": "This is a string",
+			"oneOf": [
 				{
 					"title": "null",
 					"type": "null"
@@ -268,12 +270,16 @@
 					"type": "string"
 				}
 			],
-			"default": "a string",
-			"description": "This is a string",
 			"title": "a_string: Select a type"
 		},
 		"a_tuple": {
-			"anyOf": [
+			"default": [
+				"a",
+				1,
+				true
+			],
+			"description": "This is a tuple",
+			"oneOf": [
 				{
 					"title": "null",
 					"type": "null"
@@ -296,16 +302,12 @@
 					"type": "array"
 				}
 			],
-			"default": [
-				"a",
-				1,
-				true
-			],
-			"description": "This is a tuple",
 			"title": "a_tuple: Select a type"
 		},
 		"a_variable_in_another_file": {
-			"anyOf": [
+			"default": "",
+			"description": "a string",
+			"oneOf": [
 				{
 					"title": "null",
 					"type": "null"
@@ -315,8 +317,6 @@
 					"type": "string"
 				}
 			],
-			"default": "",
-			"description": "a string",
 			"title": "a_variable_in_another_file: Select a type"
 		},
 		"an_any_as_boolean": {
@@ -480,7 +480,13 @@
 			"title": "an_any_as_string: Select a type"
 		},
 		"an_object": {
-			"anyOf": [
+			"default": {
+				"a": "a",
+				"b": 1,
+				"c": true
+			},
+			"description": "This is an object",
+			"oneOf": [
 				{
 					"title": "null",
 					"type": "null"
@@ -507,12 +513,6 @@
 					"type": "object"
 				}
 			],
-			"default": {
-				"a": "a",
-				"b": 1,
-				"c": true
-			},
-			"description": "This is an object",
 			"title": "an_object: Select a type"
 		},
 		"an_unspecified_as_boolean": {

--- a/test/expected/simple-types/schema-with-title.json
+++ b/test/expected/simple-types/schema-with-title.json
@@ -109,7 +109,8 @@
 			"type": "object"
 		},
 		"a_nullable_string": {
-			"anyOf": [
+			"description": "This is a nullable string",
+			"oneOf": [
 				{
 					"title": "null",
 					"type": "null"
@@ -119,7 +120,6 @@
 					"type": "string"
 				}
 			],
-			"description": "This is a nullable string",
 			"title": "a_nullable_string: Select a type"
 		},
 		"a_number": {

--- a/test/expected/simple-types/schema.json
+++ b/test/expected/simple-types/schema.json
@@ -108,7 +108,8 @@
 			"type": "object"
 		},
 		"a_nullable_string": {
-			"anyOf": [
+			"description": "This is a nullable string",
+			"oneOf": [
 				{
 					"title": "null",
 					"type": "null"
@@ -118,7 +119,6 @@
 					"type": "string"
 				}
 			],
-			"description": "This is a nullable string",
 			"title": "a_nullable_string: Select a type"
 		},
 		"a_number": {

--- a/test/expected/simple/schema-nullable-all.json
+++ b/test/expected/simple/schema-nullable-all.json
@@ -3,7 +3,8 @@
 	"additionalProperties": true,
 	"properties": {
 		"age": {
-			"anyOf": [
+			"description": "Your age. Required.",
+			"oneOf": [
 				{
 					"title": "null",
 					"type": "null"
@@ -13,11 +14,12 @@
 					"type": "number"
 				}
 			],
-			"description": "Your age. Required.",
 			"title": "age: Select a type"
 		},
 		"name": {
-			"anyOf": [
+			"default": "world",
+			"description": "Your name.",
+			"oneOf": [
 				{
 					"title": "null",
 					"type": "null"
@@ -27,8 +29,6 @@
 					"type": "string"
 				}
 			],
-			"default": "world",
-			"description": "Your name.",
 			"title": "name: Select a type"
 		}
 	},


### PR DESCRIPTION
## Motivation

For a two-branch union like null | string, anyOf and oneOf validate the same.
However, JSON Schema–aware tooling (editors/IDEs, language servers) provides better IntelliSense/autocomplete with oneOf, because it can exclude the previously attempted branch and surface the next most relevant candidate.

In other words, with oneOf the editor can say “not null? then try string,” which results in more helpful completions.

## What changes

### Before
```json
{
  "storageClass": {
    "anyOf": [
      { "type": "null" },
      { "type": "string" }
    ]
  }
}
```

### After
```json
{
  "storageClass": {
    "oneOf": [
      { "type": "null" },
      { "type": "string" }
    ]
  }
}
```