### PR TITLE
fix: add .idea to .gitignore for Jetbrains IDE

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 vendor
 .vscode
 terraschema
+.idea


### PR DESCRIPTION
VSCode has a .vscode folder for repository settings, JetBrains has a .idea folder.

Since this folder wasn’t included in .gitignore, adding it now.
