### PR TITLE
Add description and deprecated support via comments for nested objects

### DIFF
--- a/README.md
+++ b/README.md
@@ -282,7 +282,8 @@ Optional declarations of the form `optional(<TYPE>)` are supported.
 Terraform has no `description` argument for attributes inside an `object` type constraint, so TerraSchema reads single-line comments (`#` or `//`) attached to those attributes and emits them as JSON Schema metadata:
 
 - A comment block on the line(s) directly above an attribute, or a trailing comment on the same line, becomes the property's `description`.
-- Within a leading comment block, a line starting with `@example:` ends the description; the remaining text of the block becomes an entry in the property's `examples` array.
+- Within a leading comment block, each line starting with `@example:` begins a new entry in the property's `examples` array. The entry collects the following comment lines (preserving indentation, so multi-line code examples work) until the next annotation.
+- A line starting with `@deprecated` sets `deprecated: true` on the property. Text after `@deprecated:` is appended to the description.
 
 For example:
 
@@ -291,8 +292,11 @@ variable "instance" {
     type = object({
         # The instance size
         # @example: t3.large
+        # @example: t3.xlarge
         size = string
         count = number # How many instances to create
+        # @deprecated: use count instead
+        number_of_instances = optional(number)
     })
 }
 ```
@@ -306,11 +310,16 @@ produces:
         "size": {
             "type": "string",
             "description": "The instance size",
-            "examples": ["t3.large"]
+            "examples": ["t3.large", "t3.xlarge"]
         },
         "count": {
             "type": "number",
             "description": "How many instances to create"
+        },
+        "number_of_instances": {
+            "type": "number",
+            "description": "use count instead",
+            "deprecated": true
         }
     },
     ...

--- a/README.md
+++ b/README.md
@@ -277,6 +277,48 @@ Invalid type specification; Optional attribute modifier expects only one argumen
 
 Optional declarations of the form `optional(<TYPE>)` are supported.
 
+### Attribute Comments
+
+Terraform has no `description` argument for attributes inside an `object` type constraint, so TerraSchema reads single-line comments (`#` or `//`) attached to those attributes and emits them as JSON Schema metadata:
+
+- A comment block on the line(s) directly above an attribute, or a trailing comment on the same line, becomes the property's `description`.
+- Within a leading comment block, a line starting with `@example:` ends the description; the remaining text of the block becomes an entry in the property's `examples` array.
+
+For example:
+
+```hcl
+variable "instance" {
+    type = object({
+        # The instance size
+        # @example: t3.large
+        size = string
+        count = number # How many instances to create
+    })
+}
+```
+
+produces:
+
+```json
+{
+    "type": "object",
+    "properties": {
+        "size": {
+            "type": "string",
+            "description": "The instance size",
+            "examples": ["t3.large"]
+        },
+        "count": {
+            "type": "number",
+            "description": "How many instances to create"
+        }
+    },
+    ...
+}
+```
+
+A blank line between a comment block and an attribute breaks the association, so file headers and other detached comments are ignored, as are `/* */` block comments.
+
 ### Custom Validation Rules
 
 A subset of common validation patterns have been implemented. If a validation rule is present and can't be converted to an existing rule, then the application will print a warning. The current list of valid validation rules for a variable with the name `name` is as follows:

--- a/README.md
+++ b/README.md
@@ -279,11 +279,11 @@ Optional declarations of the form `optional(<TYPE>)` are supported.
 
 ### Attribute Comments
 
-Terraform has no `description` argument for attributes inside an `object` type constraint, so TerraSchema reads single-line comments (`#` or `//`) attached to those attributes and emits them as JSON Schema metadata:
+Terraform doesn't have a built-in way to add descriptions or deprecations to the sub-attributes of a complex type, such as an object. To work around this, terraschema uses comments in the Terraform configuration to add descriptions and deprecations to these attributes, as well as examples. It supports comments both above the attribute and trailing comments on the same line.
 
-- A comment block on the line(s) directly above an attribute, or a trailing comment on the same line, becomes the property's `description`.
-- Within a leading comment block, each line starting with `@example:` begins a new entry in the property's `examples` array. The entry collects the following comment lines (preserving indentation, so multi-line code examples work) until the next annotation.
-- A line starting with `@deprecated` sets `deprecated: true` on the property. Text after `@deprecated:` is appended to the description.
+- By default, a comment line starting with `#` or `//` is added to the description of the property.
+- If a comment starts with `@example:`, the text following it is added to the property's `examples` array.
+- If a comment starts with `@deprecated:`, the text following it is added to the property's `description` and the property is marked as deprecated. You can also use `@deprecated` without a message, in which case the property will be marked as deprecated but no message will be added to the description.
 
 For example:
 

--- a/pkg/json/json_test.go
+++ b/pkg/json/json_test.go
@@ -21,6 +21,7 @@ func TestCreateSchema(t *testing.T) {
 		"complex-types",
 		"custom-validation",
 		"ignore-variables",
+		"comments",
 	}
 	for i := range testCases {
 		name := testCases[i]

--- a/pkg/jsonschema/json-schema.go
+++ b/pkg/jsonschema/json-schema.go
@@ -19,6 +19,12 @@ type CreateSchemaOptions struct {
 	NullableAll               bool
 	IgnoreVariables           []string
 	RootProperties            map[string]string
+
+	// comment-derived metadata for the variable currently being processed, keyed by
+	// dotted attribute path, and the path of the node under construction. Options are
+	// passed by value, so mutations stay scoped to each recursion branch.
+	attributeComments map[string]model.AttributeMetadata
+	attributePath     string
 }
 
 func CreateSchema(path string, options CreateSchemaOptions) (map[string]any, error) {
@@ -80,6 +86,9 @@ func createNode(name string, v model.TranslatedVariable, options CreateSchemaOpt
 	if err != nil {
 		return nil, fmt.Errorf("getting type constraint for %q: %w", name, err)
 	}
+
+	options.attributeComments = v.ObjectComments
+	options.attributePath = ""
 
 	// The default value for nullable is the value of NullableAll. For the purpose of keeping the JSON Schema relatively
 	// clean, this is normally set to false. Setting the default value to true is consistent with Terraform behavior.

--- a/pkg/jsonschema/json-schema_test.go
+++ b/pkg/jsonschema/json-schema_test.go
@@ -14,8 +14,10 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func TestCreateSchema(t *testing.T) {
-	t.Parallel()
+// runGoldenSchemaTest runs CreateSchema with the given options against every test
+// module and compares the result with the module's golden file of the given name.
+func runGoldenSchemaTest(t *testing.T, goldenFile string, options CreateSchemaOptions) {
+	t.Helper()
 	tfPath := "../../test/modules"
 	schemaPath := "../../test/expected"
 	testCases := []string{
@@ -25,21 +27,16 @@ func TestCreateSchema(t *testing.T) {
 		"complex-types",
 		"custom-validation",
 		"ignore-variables",
+		"comments",
 	}
 	for i := range testCases {
 		name := testCases[i]
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()
-			expected, err := os.ReadFile(filepath.Join(schemaPath, name, "schema.json"))
+			expected, err := os.ReadFile(filepath.Join(schemaPath, name, goldenFile))
 			require.NoError(t, err)
 
-			result, err := CreateSchema(filepath.Join(tfPath, name), CreateSchemaOptions{
-				RequireAll:                false,
-				AllowAdditionalProperties: true,
-				AllowEmpty:                true,
-				NullableAll:               false,
-				IgnoreVariables:           []string{"ignored", "also_ignored"},
-			})
+			result, err := CreateSchema(filepath.Join(tfPath, name), options)
 			require.NoError(t, err)
 
 			var expectedMap map[string]any
@@ -53,47 +50,52 @@ func TestCreateSchema(t *testing.T) {
 	}
 }
 
+func TestCreateSchema(t *testing.T) {
+	t.Parallel()
+	runGoldenSchemaTest(t, "schema.json", CreateSchemaOptions{
+		RequireAll:                false,
+		AllowAdditionalProperties: true,
+		AllowEmpty:                true,
+		NullableAll:               false,
+		IgnoreVariables:           []string{"ignored", "also_ignored"},
+	})
+}
+
 func TestCreateSchemaWithRootProperties(t *testing.T) {
 	t.Parallel()
-	tfPath := "../../test/modules"
-	schemaPath := "../../test/expected"
-	testCases := []string{
-		"empty",
-		"simple",
-		"simple-types",
-		"complex-types",
-		"custom-validation",
-		"ignore-variables",
-	}
-	for i := range testCases {
-		name := testCases[i]
-		t.Run(name, func(t *testing.T) {
-			t.Parallel()
-			expected, err := os.ReadFile(filepath.Join(schemaPath, name, "schema-with-title.json"))
-			require.NoError(t, err)
+	runGoldenSchemaTest(t, "schema-with-title.json", CreateSchemaOptions{
+		RequireAll:                false,
+		AllowAdditionalProperties: true,
+		AllowEmpty:                true,
+		NullableAll:               false,
+		IgnoreVariables:           []string{"ignored", "also_ignored"},
+		RootProperties: map[string]string{
+			"$id":   "http://example.com/schema",
+			"title": "Example Schema",
+		},
+	})
+}
 
-			result, err := CreateSchema(filepath.Join(tfPath, name), CreateSchemaOptions{
-				RequireAll:                false,
-				AllowAdditionalProperties: true,
-				AllowEmpty:                true,
-				NullableAll:               false,
-				IgnoreVariables:           []string{"ignored", "also_ignored"},
-				RootProperties: map[string]string{
-					"$id":   "http://example.com/schema",
-					"title": "Example Schema",
-				},
-			})
-			require.NoError(t, err)
+func TestCreateSchemaNullableAll(t *testing.T) {
+	t.Parallel()
+	runGoldenSchemaTest(t, "schema-nullable-all.json", CreateSchemaOptions{
+		RequireAll:                false,
+		AllowAdditionalProperties: true,
+		AllowEmpty:                true,
+		NullableAll:               true,
+		IgnoreVariables:           []string{"ignored", "also_ignored"},
+	})
+}
 
-			var expectedMap map[string]any
-			err = json.Unmarshal(expected, &expectedMap)
-			require.NoError(t, err)
-
-			if d := cmp.Diff(expectedMap, result); d != "" {
-				t.Errorf("Schema has incorrect value (-want,+got):\n%s", d)
-			}
-		})
-	}
+func TestCreateSchemaDisallowAdditional(t *testing.T) {
+	t.Parallel()
+	runGoldenSchemaTest(t, "schema-disallow-additional.json", CreateSchemaOptions{
+		RequireAll:                false,
+		AllowAdditionalProperties: false,
+		AllowEmpty:                true,
+		NullableAll:               false,
+		IgnoreVariables:           []string{"ignored", "also_ignored"},
+	})
 }
 
 type errorLocation struct {

--- a/pkg/jsonschema/type.go
+++ b/pkg/jsonschema/type.go
@@ -4,6 +4,7 @@ package jsonschema
 import (
 	"fmt"
 	"slices"
+	"strconv"
 )
 
 var simpleTypeMap = map[string]string{
@@ -304,8 +305,10 @@ func getTuple(in []any, options CreateSchemaOptions) (map[string]any, error) {
 		return nil, fmt.Errorf("tuple's second argument must be an array, %v", in)
 	}
 
-	for _, val := range typeSlice {
-		newNode, err := getNodeFromType("", val, false, options)
+	for i, val := range typeSlice {
+		// tuple elements extend the attribute path with their index, matching the
+		// comment extraction walk in pkg/reader.
+		newNode, err := getNodeFromType("", val, false, optionsForAttribute(options, strconv.Itoa(i)))
 		if err != nil {
 			return nil, fmt.Errorf("tuple: %w", err)
 		}

--- a/pkg/jsonschema/type.go
+++ b/pkg/jsonschema/type.go
@@ -234,6 +234,9 @@ func applyAttributeComments(node map[string]any, options CreateSchemaOptions) {
 		}
 		node["examples"] = examples
 	}
+	if meta.Deprecated {
+		node["deprecated"] = true
+	}
 }
 
 func getMap(in []any, options CreateSchemaOptions) (map[string]any, error) {

--- a/pkg/jsonschema/type.go
+++ b/pkg/jsonschema/type.go
@@ -185,10 +185,12 @@ func getObject(in []any, options CreateSchemaOptions) (map[string]any, error) {
 	properties := make(map[string]any)
 
 	for key, val := range inMap {
-		newNode, err := getNodeFromType("", val, false, options)
+		childOptions := optionsForAttribute(options, key)
+		newNode, err := getNodeFromType("", val, false, childOptions)
 		if err != nil {
 			return nil, fmt.Errorf("object property %q: %w", key, err)
 		}
+		applyAttributeComments(newNode, childOptions)
 		properties[key] = newNode
 		// if the variable of the sub-object is marked as optional but RequireAll is true, then it is required.
 		if !optionals[key] || options.RequireAll {
@@ -202,6 +204,36 @@ func getObject(in []any, options CreateSchemaOptions) (map[string]any, error) {
 	node["required"] = required
 
 	return node, nil
+}
+
+// optionsForAttribute extends the dotted attribute path with the given key, so
+// that nested nodes can look up their comment-derived metadata.
+func optionsForAttribute(options CreateSchemaOptions, key string) CreateSchemaOptions {
+	childOptions := options
+	if options.attributePath == "" {
+		childOptions.attributePath = key
+	} else {
+		childOptions.attributePath = options.attributePath + "." + key
+	}
+
+	return childOptions
+}
+
+func applyAttributeComments(node map[string]any, options CreateSchemaOptions) {
+	meta, ok := options.attributeComments[options.attributePath]
+	if !ok {
+		return
+	}
+	if meta.Description != "" {
+		node["description"] = meta.Description
+	}
+	if len(meta.Examples) > 0 {
+		examples := make([]any, len(meta.Examples))
+		for i, example := range meta.Examples {
+			examples[i] = example
+		}
+		node["examples"] = examples
+	}
 }
 
 func getMap(in []any, options CreateSchemaOptions) (map[string]any, error) {

--- a/pkg/model/model.go
+++ b/pkg/model/model.go
@@ -29,6 +29,13 @@ type ValidationBlock struct {
 	Other hcl.Body `hcl:",remain"`
 }
 
+// AttributeMetadata holds documentation extracted from comments attached to an
+// attribute inside an object type constraint.
+type AttributeMetadata struct {
+	Description string
+	Examples    []string
+}
+
 // TranslatedVariable contains the Variable struct, as well as some extra information that can be used for debugging.
 // This is done here because it can be difficult to extract this information from pure hcl.Expressions as present in
 // the Variable struct without further context. Required is used internally, and the others are for debugging.
@@ -42,6 +49,10 @@ type TranslatedVariable struct {
 	TypeAsString *string
 	// Required is true if and only if the variable has no default value.
 	Required bool
+	// ObjectComments maps dotted attribute paths within this variable's object type
+	// constraint (e.g. "e", "e.a") to comment-derived metadata. It is kept out of the
+	// type constraint tree so that --export-variables output is unaffected.
+	ObjectComments map[string]AttributeMetadata
 	// The variable block used to generate the other fields in this struct.
 	Variable VariableBlock
 }

--- a/pkg/model/model.go
+++ b/pkg/model/model.go
@@ -34,6 +34,7 @@ type ValidationBlock struct {
 type AttributeMetadata struct {
 	Description string
 	Examples    []string
+	Deprecated  bool
 }
 
 // TranslatedVariable contains the Variable struct, as well as some extra information that can be used for debugging.

--- a/pkg/reader/comments.go
+++ b/pkg/reader/comments.go
@@ -1,0 +1,220 @@
+// (C) Copyright 2024 Hewlett Packard Enterprise Development LP
+package reader
+
+import (
+	"strings"
+
+	"github.com/hashicorp/hcl/v2"
+	"github.com/hashicorp/hcl/v2/hclsyntax"
+
+	"github.com/HewlettPackard/terraschema/pkg/model"
+)
+
+const exampleMarker = "@example:"
+
+type trailingComment struct {
+	text      string
+	startByte int
+}
+
+// fileComments indexes the single-line comments of one .tf file by line number.
+// Comments are not part of the HCL AST, so they are recovered by re-lexing the
+// raw source bytes.
+type fileComments struct {
+	// standalone holds comments that are the only content on their line.
+	standalone map[int]string
+	// trailing holds comments preceded by code on the same line.
+	trailing map[int]trailingComment
+}
+
+func indexFileComments(file *hcl.File, fileName string) *fileComments {
+	fc := &fileComments{
+		standalone: make(map[int]string),
+		trailing:   make(map[int]trailingComment),
+	}
+
+	// the file has already been parsed successfully, so lex diagnostics are not expected.
+	tokens, d := hclsyntax.LexConfig(file.Bytes, fileName, hcl.InitialPos)
+	if d.HasErrors() {
+		return fc
+	}
+
+	codeLines := make(map[int]bool)
+	for _, token := range tokens {
+		switch token.Type {
+		case hclsyntax.TokenComment, hclsyntax.TokenNewline, hclsyntax.TokenEOF:
+			continue
+		default:
+			for line := token.Range.Start.Line; line <= token.Range.End.Line; line++ {
+				codeLines[line] = true
+			}
+		}
+	}
+
+	for _, token := range tokens {
+		if token.Type != hclsyntax.TokenComment {
+			continue
+		}
+		raw := string(token.Bytes)
+		// only single-line comments attach to attributes; /* */ blocks are ignored.
+		if !strings.HasPrefix(raw, "#") && !strings.HasPrefix(raw, "//") {
+			continue
+		}
+		line := token.Range.Start.Line
+		text := stripCommentMarker(raw)
+		if codeLines[line] {
+			fc.trailing[line] = trailingComment{text: text, startByte: token.Range.Start.Byte}
+		} else {
+			fc.standalone[line] = text
+		}
+	}
+
+	return fc
+}
+
+func stripCommentMarker(raw string) string {
+	text := strings.TrimRight(raw, "\r\n")
+	text = strings.TrimRight(text, " \t")
+	if strings.HasPrefix(text, "//") {
+		text = text[2:]
+	} else {
+		text = strings.TrimPrefix(text, "#")
+	}
+
+	return strings.TrimPrefix(text, " ")
+}
+
+// extractObjectAttributeComments finds comments attached to attributes inside
+// object(...) type constraints within expr, keyed by dotted attribute path
+// (e.g. "e", "e.a"). It returns nil if nothing attaches.
+func extractObjectAttributeComments(expr hcl.Expression, fc *fileComments) map[string]model.AttributeMetadata {
+	syntaxExpr, ok := expr.(hclsyntax.Expression)
+	if !ok || fc == nil {
+		return nil
+	}
+
+	out := make(map[string]model.AttributeMetadata)
+	collectObjectComments(syntaxExpr, "", fc, out)
+	if len(out) == 0 {
+		return nil
+	}
+
+	return out
+}
+
+func collectObjectComments(expr hclsyntax.Expression, prefix string, fc *fileComments, out map[string]model.AttributeMetadata) {
+	switch e := expr.(type) {
+	case *hclsyntax.FunctionCallExpr:
+		if e.Name == "object" && len(e.Args) == 1 {
+			if objExpr, ok := e.Args[0].(*hclsyntax.ObjectConsExpr); ok {
+				collectFromObjectCons(objExpr, prefix, fc, out)
+
+				return
+			}
+		}
+		// wrapper types (optional, list, set, map, tuple) add no path segment,
+		// mirroring the JSON schema recursion.
+		for _, arg := range e.Args {
+			collectObjectComments(arg, prefix, fc, out)
+		}
+	case *hclsyntax.TupleConsExpr:
+		for _, item := range e.Exprs {
+			collectObjectComments(item, prefix, fc, out)
+		}
+	}
+}
+
+func collectFromObjectCons(
+	obj *hclsyntax.ObjectConsExpr,
+	prefix string,
+	fc *fileComments,
+	out map[string]model.AttributeMetadata,
+) {
+	// a trailing comment on a line where several attributes end belongs to the last one.
+	lastEndOnLine := make(map[int]int)
+	for _, item := range obj.Items {
+		endRange := item.ValueExpr.Range()
+		if endRange.End.Byte > lastEndOnLine[endRange.End.Line] {
+			lastEndOnLine[endRange.End.Line] = endRange.End.Byte
+		}
+	}
+
+	for _, item := range obj.Items {
+		traversal, d := hcl.AbsTraversalForExpr(item.KeyExpr)
+		if d.HasErrors() || len(traversal) == 0 {
+			continue
+		}
+		name := traversal.RootName()
+
+		path := name
+		if prefix != "" {
+			path = prefix + "." + name
+		}
+
+		description, examples := parseLeadingBlock(leadingCommentLines(item, obj, fc))
+		if description == "" {
+			if text, ok := trailingCommentText(item, fc, lastEndOnLine); ok {
+				description = text
+			}
+		}
+		if description != "" || len(examples) > 0 {
+			out[path] = model.AttributeMetadata{Description: description, Examples: examples}
+		}
+
+		collectObjectComments(item.ValueExpr, path, fc, out)
+	}
+}
+
+// leadingCommentLines collects the contiguous block of standalone comment lines
+// directly above the attribute, in source order. The walk stops at the opening
+// line of the enclosing object so that comments above the whole type expression
+// (e.g. file headers) never attach to the first attribute.
+func leadingCommentLines(item hclsyntax.ObjectConsItem, obj *hclsyntax.ObjectConsExpr, fc *fileComments) []string {
+	var lines []string
+	keyLine := item.KeyExpr.Range().Start.Line
+	for line := keyLine - 1; line > obj.SrcRange.Start.Line; line-- {
+		text, ok := fc.standalone[line]
+		if !ok {
+			break
+		}
+		lines = append([]string{text}, lines...)
+	}
+
+	return lines
+}
+
+func trailingCommentText(item hclsyntax.ObjectConsItem, fc *fileComments, lastEndOnLine map[int]int) (string, bool) {
+	endRange := item.ValueExpr.Range()
+	if endRange.End.Byte != lastEndOnLine[endRange.End.Line] {
+		return "", false
+	}
+	tc, ok := fc.trailing[endRange.End.Line]
+	if !ok || tc.startByte < endRange.End.Byte {
+		return "", false
+	}
+
+	return tc.text, true
+}
+
+// parseLeadingBlock splits a leading comment block into a description and an
+// optional single example: lines before the first "@example:" line form the
+// description, and everything from that marker onward forms one example string.
+func parseLeadingBlock(lines []string) (string, []string) {
+	exampleIndex := -1
+	for i, line := range lines {
+		if strings.HasPrefix(line, exampleMarker) {
+			exampleIndex = i
+
+			break
+		}
+	}
+	if exampleIndex == -1 {
+		return strings.Join(lines, "\n"), nil
+	}
+
+	description := strings.Join(lines[:exampleIndex], "\n")
+	first := strings.TrimPrefix(strings.TrimPrefix(lines[exampleIndex], exampleMarker), " ")
+	exampleLines := append([]string{first}, lines[exampleIndex+1:]...)
+
+	return description, []string{strings.Join(exampleLines, "\n")}
+}

--- a/pkg/reader/comments.go
+++ b/pkg/reader/comments.go
@@ -10,7 +10,10 @@ import (
 	"github.com/HewlettPackard/terraschema/pkg/model"
 )
 
-const exampleMarker = "@example:"
+const (
+	exampleMarker    = "@example:"
+	deprecatedMarker = "@deprecated"
+)
 
 type trailingComment struct {
 	text      string
@@ -151,14 +154,14 @@ func collectFromObjectCons(
 			path = prefix + "." + name
 		}
 
-		description, examples := parseLeadingBlock(leadingCommentLines(item, obj, fc))
-		if description == "" {
+		meta := parseLeadingBlock(leadingCommentLines(item, obj, fc))
+		if meta.Description == "" {
 			if text, ok := trailingCommentText(item, fc, lastEndOnLine); ok {
-				description = text
+				meta.Description = text
 			}
 		}
-		if description != "" || len(examples) > 0 {
-			out[path] = model.AttributeMetadata{Description: description, Examples: examples}
+		if meta.Description != "" || len(meta.Examples) > 0 || meta.Deprecated {
+			out[path] = meta
 		}
 
 		collectObjectComments(item.ValueExpr, path, fc, out)
@@ -196,25 +199,51 @@ func trailingCommentText(item hclsyntax.ObjectConsItem, fc *fileComments, lastEn
 	return tc.text, true
 }
 
-// parseLeadingBlock splits a leading comment block into a description and an
-// optional single example: lines before the first "@example:" line form the
-// description, and everything from that marker onward forms one example string.
-func parseLeadingBlock(lines []string) (string, []string) {
-	exampleIndex := -1
-	for i, line := range lines {
-		if strings.HasPrefix(line, exampleMarker) {
-			exampleIndex = i
-
-			break
+// parseLeadingBlock interprets a leading comment block as a description with
+// optional annotations. Each "@example:" line starts a new example, which
+// collects the following lines until the next annotation. An "@deprecated"
+// line marks the attribute deprecated; any text after it (and any later plain
+// lines) continues the description.
+func parseLeadingBlock(lines []string) model.AttributeMetadata {
+	var meta model.AttributeMetadata
+	var description []string
+	var examples [][]string
+	// index of the example currently being collected, or -1 for the description.
+	target := -1
+	for _, line := range lines {
+		switch {
+		case strings.HasPrefix(line, exampleMarker):
+			examples = append(examples, annotationText(line, exampleMarker))
+			target = len(examples) - 1
+		case strings.HasPrefix(line, deprecatedMarker):
+			meta.Deprecated = true
+			description = append(description, annotationText(line, deprecatedMarker)...)
+			target = -1
+		case target == -1:
+			description = append(description, line)
+		default:
+			examples[target] = append(examples[target], line)
 		}
 	}
-	if exampleIndex == -1 {
-		return strings.Join(lines, "\n"), nil
+
+	meta.Description = strings.Join(description, "\n")
+	for _, example := range examples {
+		meta.Examples = append(meta.Examples, strings.Join(example, "\n"))
 	}
 
-	description := strings.Join(lines[:exampleIndex], "\n")
-	first := strings.TrimPrefix(strings.TrimPrefix(lines[exampleIndex], exampleMarker), " ")
-	exampleLines := append([]string{first}, lines[exampleIndex+1:]...)
+	return meta
+}
 
-	return description, []string{strings.Join(exampleLines, "\n")}
+// annotationText returns the text of an annotation line after its marker as a
+// slice of zero or one lines, so that markers on a line of their own do not
+// contribute an empty line to the collected block.
+func annotationText(line, marker string) []string {
+	text := strings.TrimPrefix(line, marker)
+	text = strings.TrimPrefix(text, ":")
+	text = strings.TrimPrefix(text, " ")
+	if text == "" {
+		return nil
+	}
+
+	return []string{text}
 }

--- a/pkg/reader/comments.go
+++ b/pkg/reader/comments.go
@@ -2,6 +2,8 @@
 package reader
 
 import (
+	"slices"
+	"strconv"
 	"strings"
 
 	"github.com/hashicorp/hcl/v2"
@@ -89,110 +91,141 @@ func stripCommentMarker(raw string) string {
 
 // extractObjectAttributeComments finds comments attached to attributes inside
 // object(...) type constraints within expr, keyed by dotted attribute path
-// (e.g. "e", "e.a"). It returns nil if nothing attaches.
+// (e.g. "e", "e.a"; tuple elements add their index, e.g. "t.0.name"). It
+// returns nil if nothing attaches.
 func extractObjectAttributeComments(expr hcl.Expression, fc *fileComments) map[string]model.AttributeMetadata {
 	syntaxExpr, ok := expr.(hclsyntax.Expression)
 	if !ok || fc == nil {
 		return nil
 	}
 
-	out := make(map[string]model.AttributeMetadata)
-	collectObjectComments(syntaxExpr, "", fc, out)
-	if len(out) == 0 {
+	w := &commentWalker{
+		fc:         fc,
+		lineMaxEnd: make(map[int]int),
+		out:        make(map[string]model.AttributeMetadata),
+	}
+	w.recordLineEnds(syntaxExpr)
+	w.collect(syntaxExpr, "")
+	if len(w.out) == 0 {
 		return nil
 	}
 
-	return out
+	return w.out
 }
 
-func collectObjectComments(expr hclsyntax.Expression, prefix string, fc *fileComments, out map[string]model.AttributeMetadata) {
+// commentWalker carries the state of one walk over a type expression.
+type commentWalker struct {
+	fc *fileComments
+	// lineMaxEnd holds, per line, the greatest end byte of any expression that
+	// ends on that line. A trailing comment attaches to an attribute only if the
+	// attribute's value is the last expression ending before it, so a comment
+	// after the closing brackets of a nested construct never attaches to the
+	// attributes inside it.
+	lineMaxEnd map[int]int
+	out        map[string]model.AttributeMetadata
+}
+
+func (w *commentWalker) recordLineEnds(expr hclsyntax.Expression) {
+	endPos := expr.Range().End
+	if endPos.Byte > w.lineMaxEnd[endPos.Line] {
+		w.lineMaxEnd[endPos.Line] = endPos.Byte
+	}
+	switch e := expr.(type) {
+	case *hclsyntax.FunctionCallExpr:
+		for _, arg := range e.Args {
+			w.recordLineEnds(arg)
+		}
+	case *hclsyntax.TupleConsExpr:
+		for _, element := range e.Exprs {
+			w.recordLineEnds(element)
+		}
+	case *hclsyntax.ObjectConsExpr:
+		for _, item := range e.Items {
+			w.recordLineEnds(item.ValueExpr)
+		}
+	}
+}
+
+func (w *commentWalker) collect(expr hclsyntax.Expression, prefix string) {
 	switch e := expr.(type) {
 	case *hclsyntax.FunctionCallExpr:
 		if e.Name == "object" && len(e.Args) == 1 {
 			if objExpr, ok := e.Args[0].(*hclsyntax.ObjectConsExpr); ok {
-				collectFromObjectCons(objExpr, prefix, fc, out)
+				w.collectObject(objExpr, prefix)
 
 				return
 			}
 		}
-		// wrapper types (optional, list, set, map, tuple) add no path segment,
+		// wrapper types (optional, list, set, map) add no path segment,
 		// mirroring the JSON schema recursion.
 		for _, arg := range e.Args {
-			collectObjectComments(arg, prefix, fc, out)
+			w.collect(arg, prefix)
 		}
 	case *hclsyntax.TupleConsExpr:
-		for _, item := range e.Exprs {
-			collectObjectComments(item, prefix, fc, out)
+		// tuple elements are addressed by index, as in the JSON schema recursion,
+		// so same-named attributes in different elements do not collide.
+		for i, element := range e.Exprs {
+			w.collect(element, joinPath(prefix, strconv.Itoa(i)))
 		}
 	}
 }
 
-func collectFromObjectCons(
-	obj *hclsyntax.ObjectConsExpr,
-	prefix string,
-	fc *fileComments,
-	out map[string]model.AttributeMetadata,
-) {
-	// a trailing comment on a line where several attributes end belongs to the last one.
-	lastEndOnLine := make(map[int]int)
-	for _, item := range obj.Items {
-		endRange := item.ValueExpr.Range()
-		if endRange.End.Byte > lastEndOnLine[endRange.End.Line] {
-			lastEndOnLine[endRange.End.Line] = endRange.End.Byte
-		}
-	}
-
+func (w *commentWalker) collectObject(obj *hclsyntax.ObjectConsExpr, prefix string) {
 	for _, item := range obj.Items {
 		traversal, d := hcl.AbsTraversalForExpr(item.KeyExpr)
 		if d.HasErrors() || len(traversal) == 0 {
 			continue
 		}
-		name := traversal.RootName()
+		path := joinPath(prefix, traversal.RootName())
 
-		path := name
-		if prefix != "" {
-			path = prefix + "." + name
-		}
-
-		meta := parseLeadingBlock(leadingCommentLines(item, obj, fc))
+		meta := parseLeadingBlock(w.leadingCommentLines(item, obj))
 		if meta.Description == "" {
-			if text, ok := trailingCommentText(item, fc, lastEndOnLine); ok {
+			if text, ok := w.trailingCommentText(item); ok {
 				meta.Description = text
 			}
 		}
 		if meta.Description != "" || len(meta.Examples) > 0 || meta.Deprecated {
-			out[path] = meta
+			w.out[path] = meta
 		}
 
-		collectObjectComments(item.ValueExpr, path, fc, out)
+		w.collect(item.ValueExpr, path)
 	}
+}
+
+func joinPath(prefix, segment string) string {
+	if prefix == "" {
+		return segment
+	}
+
+	return prefix + "." + segment
 }
 
 // leadingCommentLines collects the contiguous block of standalone comment lines
 // directly above the attribute, in source order. The walk stops at the opening
 // line of the enclosing object so that comments above the whole type expression
 // (e.g. file headers) never attach to the first attribute.
-func leadingCommentLines(item hclsyntax.ObjectConsItem, obj *hclsyntax.ObjectConsExpr, fc *fileComments) []string {
+func (w *commentWalker) leadingCommentLines(item hclsyntax.ObjectConsItem, obj *hclsyntax.ObjectConsExpr) []string {
 	var lines []string
 	keyLine := item.KeyExpr.Range().Start.Line
 	for line := keyLine - 1; line > obj.SrcRange.Start.Line; line-- {
-		text, ok := fc.standalone[line]
+		text, ok := w.fc.standalone[line]
 		if !ok {
 			break
 		}
-		lines = append([]string{text}, lines...)
+		lines = append(lines, text)
 	}
+	slices.Reverse(lines)
 
 	return lines
 }
 
-func trailingCommentText(item hclsyntax.ObjectConsItem, fc *fileComments, lastEndOnLine map[int]int) (string, bool) {
-	endRange := item.ValueExpr.Range()
-	if endRange.End.Byte != lastEndOnLine[endRange.End.Line] {
+func (w *commentWalker) trailingCommentText(item hclsyntax.ObjectConsItem) (string, bool) {
+	endPos := item.ValueExpr.Range().End
+	if endPos.Byte != w.lineMaxEnd[endPos.Line] {
 		return "", false
 	}
-	tc, ok := fc.trailing[endRange.End.Line]
-	if !ok || tc.startByte < endRange.End.Byte {
+	tc, ok := w.fc.trailing[endPos.Line]
+	if !ok || tc.startByte < endPos.Byte {
 		return "", false
 	}
 
@@ -215,7 +248,7 @@ func parseLeadingBlock(lines []string) model.AttributeMetadata {
 		case strings.HasPrefix(line, exampleMarker):
 			examples = append(examples, annotationText(line, exampleMarker))
 			target = len(examples) - 1
-		case strings.HasPrefix(line, deprecatedMarker):
+		case isDeprecatedLine(line):
 			meta.Deprecated = true
 			description = append(description, annotationText(line, deprecatedMarker)...)
 			target = -1
@@ -232,6 +265,18 @@ func parseLeadingBlock(lines []string) model.AttributeMetadata {
 	}
 
 	return meta
+}
+
+// isDeprecatedLine reports whether the line is an @deprecated annotation. The
+// marker must be the whole word: longer words such as "@deprecated_in_v3" are
+// plain description text.
+func isDeprecatedLine(line string) bool {
+	rest, found := strings.CutPrefix(line, deprecatedMarker)
+	if !found {
+		return false
+	}
+
+	return rest == "" || strings.HasPrefix(rest, ":") || strings.HasPrefix(rest, " ") || strings.HasPrefix(rest, "\t")
 }
 
 // annotationText returns the text of an annotation line after its marker as a

--- a/pkg/reader/comments_test.go
+++ b/pkg/reader/comments_test.go
@@ -158,6 +158,54 @@ variable "v" {
 				"c.d": {Description: "nested in list"},
 			},
 		},
+		"tuple elements have distinct paths": {
+			src: `
+variable "v" {
+	type = object({
+		t = tuple([object({
+			# first
+			name = string
+		}), object({
+			# second
+			name = string
+		})])
+	})
+}`,
+			expected: map[string]model.AttributeMetadata{
+				"t.0.name": {Description: "first"},
+				"t.1.name": {Description: "second"},
+			},
+		},
+		"trailing comment after inline nested object attaches to outer attribute only": {
+			src: `
+variable "v" {
+	type = object({
+		a = object({ x = string }) # about a
+	})
+}`,
+			expected: map[string]model.AttributeMetadata{
+				"a": {Description: "about a"},
+			},
+		},
+		"trailing comment after whole type does not attach": {
+			src: `
+variable "v" {
+	type = object({ a = string }) # about the variable
+}`,
+			expected: nil,
+		},
+		"deprecated marker requires a word boundary": {
+			src: `
+variable "v" {
+	type = object({
+		# @deprecated_in_v3 use b instead
+		a = string
+	})
+}`,
+			expected: map[string]model.AttributeMetadata{
+				"a": {Description: "@deprecated_in_v3 use b instead"},
+			},
+		},
 		"comment above one-line object does not attach": {
 			src: `
 variable "v" {
@@ -233,6 +281,12 @@ func TestParseLeadingBlock(t *testing.T) {
 			expected: model.AttributeMetadata{
 				Description: "a description\nuse something else",
 				Deprecated:  true,
+			},
+		},
+		"deprecated requires word boundary": {
+			lines: []string{"@deprecated_in_v3 use something else"},
+			expected: model.AttributeMetadata{
+				Description: "@deprecated_in_v3 use something else",
 			},
 		},
 		"description resumes after deprecated": {

--- a/pkg/reader/comments_test.go
+++ b/pkg/reader/comments_test.go
@@ -1,0 +1,176 @@
+// (C) Copyright 2024 Hewlett Packard Enterprise Development LP
+package reader
+
+import (
+	"testing"
+
+	"github.com/hashicorp/hcl/v2/hclparse"
+	"github.com/stretchr/testify/require"
+
+	"github.com/HewlettPackard/terraschema/pkg/model"
+)
+
+// objectCommentsFromSource parses HCL source containing a single variable block
+// and returns the comment metadata extracted from its type expression.
+func objectCommentsFromSource(t *testing.T, src string) map[string]model.AttributeMetadata {
+	t.Helper()
+	parser := hclparse.NewParser()
+	file, d := parser.ParseHCL([]byte(src), "test.tf")
+	require.False(t, d.HasErrors(), d)
+
+	blocks, _, d := file.Body.PartialContent(fileSchema)
+	require.False(t, d.HasErrors(), d)
+	require.Len(t, blocks.Blocks, 1)
+
+	comments := indexFileComments(file, "test.tf")
+	_, translated, err := getTranslatedVariableFromBlock(blocks.Blocks[0], file, comments)
+	require.NoError(t, err)
+
+	return translated.ObjectComments
+}
+
+func TestExtractObjectAttributeComments(t *testing.T) {
+	t.Parallel()
+	testCases := map[string]struct {
+		src      string
+		expected map[string]model.AttributeMetadata
+	}{
+		"leading and trailing comments": {
+			src: `
+variable "v" {
+	type = object({
+		# This is A
+		a = string
+		b = number # This is B
+		c = bool
+	})
+}`,
+			expected: map[string]model.AttributeMetadata{
+				"a": {Description: "This is A"},
+				"b": {Description: "This is B"},
+			},
+		},
+		"blank line breaks adjacency": {
+			src: `
+# file header comment
+variable "v" {
+	type = object({
+		# detached comment
+
+		a = string
+	})
+}`,
+			expected: nil,
+		},
+		"double slash comments": {
+			src: `
+variable "v" {
+	type = object({
+		// This is A
+		a = string
+		b = number // This is B
+	})
+}`,
+			expected: map[string]model.AttributeMetadata{
+				"a": {Description: "This is A"},
+				"b": {Description: "This is B"},
+			},
+		},
+		"example annotation": {
+			src: `
+variable "v" {
+	type = object({
+		# This is A
+		# @example: line one
+		# line two
+		a = string
+		# @example: only an example
+		b = number
+	})
+}`,
+			expected: map[string]model.AttributeMetadata{
+				"a": {Description: "This is A", Examples: []string{"line one\nline two"}},
+				"b": {Examples: []string{"only an example"}},
+			},
+		},
+		"nested objects in wrapper types": {
+			src: `
+variable "v" {
+	type = object({
+		a = optional(object({
+			# nested in optional
+			b = string
+		}))
+		c = list(object({
+			d = number # nested in list
+		}))
+	})
+}`,
+			expected: map[string]model.AttributeMetadata{
+				"a.b": {Description: "nested in optional"},
+				"c.d": {Description: "nested in list"},
+			},
+		},
+		"comment above one-line object does not attach": {
+			src: `
+variable "v" {
+	# comment above the type
+	type = object({ a = string })
+}`,
+			expected: nil,
+		},
+		"block comments are ignored": {
+			src: `
+variable "v" {
+	type = object({
+		/* block comment */
+		a = string
+	})
+}`,
+			expected: nil,
+		},
+	}
+
+	for name, tc := range testCases {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+			result := objectCommentsFromSource(t, tc.src)
+			require.Equal(t, tc.expected, result)
+		})
+	}
+}
+
+func TestParseLeadingBlock(t *testing.T) {
+	t.Parallel()
+	testCases := map[string]struct {
+		lines               []string
+		expectedDescription string
+		expectedExamples    []string
+	}{
+		"no lines": {
+			lines: nil,
+		},
+		"description only": {
+			lines:               []string{"line one", "line two"},
+			expectedDescription: "line one\nline two",
+		},
+		"description and example": {
+			lines:               []string{"a description", "@example: first", "second"},
+			expectedDescription: "a description",
+			expectedExamples:    []string{"first\nsecond"},
+		},
+		"example only": {
+			lines:            []string{"@example: just this"},
+			expectedExamples: []string{"just this"},
+		},
+	}
+
+	for name, tc := range testCases {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+			description, examples := parseLeadingBlock(tc.lines)
+			require.Equal(t, tc.expectedDescription, description)
+			require.Equal(t, tc.expectedExamples, examples)
+		})
+	}
+}

--- a/pkg/reader/comments_test.go
+++ b/pkg/reader/comments_test.go
@@ -93,6 +93,53 @@ variable "v" {
 				"b": {Examples: []string{"only an example"}},
 			},
 		},
+		"multiple examples": {
+			src: `
+variable "v" {
+	type = object({
+		# This is A
+		# @example: first
+		# @example: second
+		# continues second
+		a = string
+	})
+}`,
+			expected: map[string]model.AttributeMetadata{
+				"a": {Description: "This is A", Examples: []string{"first", "second\ncontinues second"}},
+			},
+		},
+		"code example preserves indentation": {
+			src: `
+variable "v" {
+	type = object({
+		# @example:
+		# {
+		#   name = "web"
+		#   port = 8080
+		# }
+		a = string
+	})
+}`,
+			expected: map[string]model.AttributeMetadata{
+				"a": {Examples: []string{"{\n  name = \"web\"\n  port = 8080\n}"}},
+			},
+		},
+		"deprecated annotation": {
+			src: `
+variable "v" {
+	type = object({
+		# This is A
+		# @deprecated
+		a = string
+		# @deprecated: use A instead
+		b = number
+	})
+}`,
+			expected: map[string]model.AttributeMetadata{
+				"a": {Description: "This is A", Deprecated: true},
+				"b": {Description: "use A instead", Deprecated: true},
+			},
+		},
 		"nested objects in wrapper types": {
 			src: `
 variable "v" {
@@ -143,34 +190,65 @@ variable "v" {
 func TestParseLeadingBlock(t *testing.T) {
 	t.Parallel()
 	testCases := map[string]struct {
-		lines               []string
-		expectedDescription string
-		expectedExamples    []string
+		lines    []string
+		expected model.AttributeMetadata
 	}{
 		"no lines": {
 			lines: nil,
 		},
 		"description only": {
-			lines:               []string{"line one", "line two"},
-			expectedDescription: "line one\nline two",
+			lines:    []string{"line one", "line two"},
+			expected: model.AttributeMetadata{Description: "line one\nline two"},
 		},
 		"description and example": {
-			lines:               []string{"a description", "@example: first", "second"},
-			expectedDescription: "a description",
-			expectedExamples:    []string{"first\nsecond"},
+			lines: []string{"a description", "@example: first", "second"},
+			expected: model.AttributeMetadata{
+				Description: "a description",
+				Examples:    []string{"first\nsecond"},
+			},
 		},
 		"example only": {
-			lines:            []string{"@example: just this"},
-			expectedExamples: []string{"just this"},
+			lines:    []string{"@example: just this"},
+			expected: model.AttributeMetadata{Examples: []string{"just this"}},
+		},
+		"multiple examples": {
+			lines: []string{"a description", "@example: first", "@example: second", "more of second"},
+			expected: model.AttributeMetadata{
+				Description: "a description",
+				Examples:    []string{"first", "second\nmore of second"},
+			},
+		},
+		"example on its own lines": {
+			lines: []string{"@example:", "{", "  a = 1", "}"},
+			expected: model.AttributeMetadata{
+				Examples: []string{"{\n  a = 1\n}"},
+			},
+		},
+		"deprecated only": {
+			lines:    []string{"@deprecated"},
+			expected: model.AttributeMetadata{Deprecated: true},
+		},
+		"deprecated with reason": {
+			lines: []string{"a description", "@deprecated: use something else"},
+			expected: model.AttributeMetadata{
+				Description: "a description\nuse something else",
+				Deprecated:  true,
+			},
+		},
+		"description resumes after deprecated": {
+			lines: []string{"@example: an example", "@deprecated", "more description"},
+			expected: model.AttributeMetadata{
+				Description: "more description",
+				Examples:    []string{"an example"},
+				Deprecated:  true,
+			},
 		},
 	}
 
 	for name, tc := range testCases {
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()
-			description, examples := parseLeadingBlock(tc.lines)
-			require.Equal(t, tc.expectedDescription, description)
-			require.Equal(t, tc.expectedExamples, examples)
+			require.Equal(t, tc.expected, parseLeadingBlock(tc.lines))
 		})
 	}
 }

--- a/pkg/reader/reader.go
+++ b/pkg/reader/reader.go
@@ -62,8 +62,9 @@ func GetVarMap(path string, debugOut bool) (map[string]model.TranslatedVariable,
 		if d.HasErrors() {
 			return nil, d
 		}
+		comments := indexFileComments(file, fileName)
 		for _, block := range blocks.Blocks {
-			name, translated, err := getTranslatedVariableFromBlock(block, file)
+			name, translated, err := getTranslatedVariableFromBlock(block, file, comments)
 			if err != nil {
 				return nil, fmt.Errorf("error getting parsing %q: %w", name, err)
 			}
@@ -82,7 +83,11 @@ func GetVarMap(path string, debugOut bool) (map[string]model.TranslatedVariable,
 	return varMap, nil
 }
 
-func getTranslatedVariableFromBlock(block *hcl.Block, file *hcl.File) (string, model.TranslatedVariable, error) {
+func getTranslatedVariableFromBlock(
+	block *hcl.Block,
+	file *hcl.File,
+	comments *fileComments,
+) (string, model.TranslatedVariable, error) {
 	name := block.Labels[0]
 	variable := model.VariableBlock{}
 	d := gohcl.DecodeBody(block.Body, nil, &variable)
@@ -109,6 +114,7 @@ func getTranslatedVariableFromBlock(block *hcl.Block, file *hcl.File) (string, m
 	if variable.Type != nil {
 		typeAsString := printToString(variable.Type, file)
 		out.TypeAsString = &typeAsString
+		out.ObjectComments = extractObjectAttributeComments(variable.Type, comments)
 	}
 
 	// plaintext print all condition expressions into the ConditionsAsString field.

--- a/test/expected/comments/schema-disallow-additional.json
+++ b/test/expected/comments/schema-disallow-additional.json
@@ -1,0 +1,51 @@
+{
+	"$schema": "http://json-schema.org/draft-07/schema#",
+	"additionalProperties": false,
+	"properties": {
+		"an_object_with_optional": {
+			"additionalProperties": false,
+			"description": "This is a nested object with comments",
+			"properties": {
+				"a": {
+					"description": "This is A",
+					"type": "string"
+				},
+				"b": {
+					"description": "This is B",
+					"type": "number"
+				},
+				"c": {
+					"type": "boolean"
+				},
+				"d": {
+					"type": "string"
+				},
+				"e": {
+					"additionalProperties": false,
+					"description": "This is E",
+					"examples": ["This is a multi-line\nexample."],
+					"properties": {
+						"a": {
+							"type": "string"
+						}
+					},
+					"required": [
+						"a"
+					],
+					"type": "object"
+				}
+			},
+			"required": [
+				"a",
+				"b",
+				"c",
+				"e"
+			],
+			"type": "object"
+		}
+	},
+	"required": [
+		"an_object_with_optional"
+	],
+	"type": "object"
+}

--- a/test/expected/comments/schema-disallow-additional.json
+++ b/test/expected/comments/schema-disallow-additional.json
@@ -55,6 +55,40 @@
 						"{\n  name    = \"web-server\"\n  port    = 8080\n  enabled = true\n}"
 					],
 					"type": "string"
+				},
+				"i": {
+					"description": "This is I",
+					"items": [
+						{
+							"additionalProperties": false,
+							"properties": {
+								"name": {
+									"description": "first element name",
+									"type": "string"
+								}
+							},
+							"required": [
+								"name"
+							],
+							"type": "object"
+						},
+						{
+							"additionalProperties": false,
+							"properties": {
+								"name": {
+									"description": "second element name",
+									"type": "string"
+								}
+							},
+							"required": [
+								"name"
+							],
+							"type": "object"
+						}
+					],
+					"maxItems": 2,
+					"minItems": 2,
+					"type": "array"
 				}
 			},
 			"required": [
@@ -63,7 +97,8 @@
 				"c",
 				"e",
 				"g",
-				"h"
+				"h",
+				"i"
 			],
 			"type": "object"
 		}

--- a/test/expected/comments/schema-disallow-additional.json
+++ b/test/expected/comments/schema-disallow-additional.json
@@ -23,7 +23,9 @@
 				"e": {
 					"additionalProperties": false,
 					"description": "This is E",
-					"examples": ["This is a multi-line\nexample."],
+					"examples": [
+						"This is a multi-line\nexample."
+					],
 					"properties": {
 						"a": {
 							"type": "string"
@@ -33,13 +35,35 @@
 						"a"
 					],
 					"type": "object"
+				},
+				"f": {
+					"deprecated": true,
+					"description": "This is F",
+					"type": "string"
+				},
+				"g": {
+					"description": "This is G",
+					"examples": [
+						"first example",
+						"second example"
+					],
+					"type": "string"
+				},
+				"h": {
+					"description": "This is H",
+					"examples": [
+						"{\n  name    = \"web-server\"\n  port    = 8080\n  enabled = true\n}"
+					],
+					"type": "string"
 				}
 			},
 			"required": [
 				"a",
 				"b",
 				"c",
-				"e"
+				"e",
+				"g",
+				"h"
 			],
 			"type": "object"
 		}

--- a/test/expected/comments/schema-nullable-all.json
+++ b/test/expected/comments/schema-nullable-all.json
@@ -61,6 +61,40 @@
 								"{\n  name    = \"web-server\"\n  port    = 8080\n  enabled = true\n}"
 							],
 							"type": "string"
+						},
+						"i": {
+							"description": "This is I",
+							"items": [
+								{
+									"additionalProperties": true,
+									"properties": {
+										"name": {
+											"description": "first element name",
+											"type": "string"
+										}
+									},
+									"required": [
+										"name"
+									],
+									"type": "object"
+								},
+								{
+									"additionalProperties": true,
+									"properties": {
+										"name": {
+											"description": "second element name",
+											"type": "string"
+										}
+									},
+									"required": [
+										"name"
+									],
+									"type": "object"
+								}
+							],
+							"maxItems": 2,
+							"minItems": 2,
+							"type": "array"
 						}
 					},
 					"required": [
@@ -69,7 +103,8 @@
 						"c",
 						"e",
 						"g",
-						"h"
+						"h",
+						"i"
 					],
 					"title": "object",
 					"type": "object"

--- a/test/expected/comments/schema-nullable-all.json
+++ b/test/expected/comments/schema-nullable-all.json
@@ -1,0 +1,61 @@
+{
+	"$schema": "http://json-schema.org/draft-07/schema#",
+	"additionalProperties": true,
+	"properties": {
+		"an_object_with_optional": {
+			"description": "This is a nested object with comments",
+			"oneOf": [
+				{
+					"title": "null",
+					"type": "null"
+				},
+				{
+					"additionalProperties": true,
+					"properties": {
+						"a": {
+							"description": "This is A",
+							"type": "string"
+						},
+						"b": {
+							"description": "This is B",
+							"type": "number"
+						},
+						"c": {
+							"type": "boolean"
+						},
+						"d": {
+							"type": "string"
+						},
+						"e": {
+							"additionalProperties": true,
+							"description": "This is E",
+							"examples": ["This is a multi-line\nexample."],
+							"properties": {
+								"a": {
+									"type": "string"
+								}
+							},
+							"required": [
+								"a"
+							],
+							"type": "object"
+						}
+					},
+					"required": [
+						"a",
+						"b",
+						"c",
+						"e"
+					],
+					"title": "object",
+					"type": "object"
+				}
+			],
+			"title": "an_object_with_optional: Select a type"
+		}
+	},
+	"required": [
+		"an_object_with_optional"
+	],
+	"type": "object"
+}

--- a/test/expected/comments/schema-nullable-all.json
+++ b/test/expected/comments/schema-nullable-all.json
@@ -29,7 +29,9 @@
 						"e": {
 							"additionalProperties": true,
 							"description": "This is E",
-							"examples": ["This is a multi-line\nexample."],
+							"examples": [
+								"This is a multi-line\nexample."
+							],
 							"properties": {
 								"a": {
 									"type": "string"
@@ -39,13 +41,35 @@
 								"a"
 							],
 							"type": "object"
+						},
+						"f": {
+							"deprecated": true,
+							"description": "This is F",
+							"type": "string"
+						},
+						"g": {
+							"description": "This is G",
+							"examples": [
+								"first example",
+								"second example"
+							],
+							"type": "string"
+						},
+						"h": {
+							"description": "This is H",
+							"examples": [
+								"{\n  name    = \"web-server\"\n  port    = 8080\n  enabled = true\n}"
+							],
+							"type": "string"
 						}
 					},
 					"required": [
 						"a",
 						"b",
 						"c",
-						"e"
+						"e",
+						"g",
+						"h"
 					],
 					"title": "object",
 					"type": "object"

--- a/test/expected/comments/schema-with-title.json
+++ b/test/expected/comments/schema-with-title.json
@@ -24,7 +24,9 @@
 				"e": {
 					"additionalProperties": true,
 					"description": "This is E",
-					"examples": ["This is a multi-line\nexample."],
+					"examples": [
+						"This is a multi-line\nexample."
+					],
 					"properties": {
 						"a": {
 							"type": "string"
@@ -34,13 +36,35 @@
 						"a"
 					],
 					"type": "object"
+				},
+				"f": {
+					"deprecated": true,
+					"description": "This is F",
+					"type": "string"
+				},
+				"g": {
+					"description": "This is G",
+					"examples": [
+						"first example",
+						"second example"
+					],
+					"type": "string"
+				},
+				"h": {
+					"description": "This is H",
+					"examples": [
+						"{\n  name    = \"web-server\"\n  port    = 8080\n  enabled = true\n}"
+					],
+					"type": "string"
 				}
 			},
 			"required": [
 				"a",
 				"b",
 				"c",
-				"e"
+				"e",
+				"g",
+				"h"
 			],
 			"type": "object"
 		}

--- a/test/expected/comments/schema-with-title.json
+++ b/test/expected/comments/schema-with-title.json
@@ -1,0 +1,53 @@
+{
+	"$id": "http://example.com/schema",
+	"$schema": "http://json-schema.org/draft-07/schema#",
+	"additionalProperties": true,
+	"properties": {
+		"an_object_with_optional": {
+			"additionalProperties": true,
+			"description": "This is a nested object with comments",
+			"properties": {
+				"a": {
+					"description": "This is A",
+					"type": "string"
+				},
+				"b": {
+					"description": "This is B",
+					"type": "number"
+				},
+				"c": {
+					"type": "boolean"
+				},
+				"d": {
+					"type": "string"
+				},
+				"e": {
+					"additionalProperties": true,
+					"description": "This is E",
+					"examples": ["This is a multi-line\nexample."],
+					"properties": {
+						"a": {
+							"type": "string"
+						}
+					},
+					"required": [
+						"a"
+					],
+					"type": "object"
+				}
+			},
+			"required": [
+				"a",
+				"b",
+				"c",
+				"e"
+			],
+			"type": "object"
+		}
+	},
+	"required": [
+		"an_object_with_optional"
+	],
+	"title": "Example Schema",
+	"type": "object"
+}

--- a/test/expected/comments/schema-with-title.json
+++ b/test/expected/comments/schema-with-title.json
@@ -56,6 +56,40 @@
 						"{\n  name    = \"web-server\"\n  port    = 8080\n  enabled = true\n}"
 					],
 					"type": "string"
+				},
+				"i": {
+					"description": "This is I",
+					"items": [
+						{
+							"additionalProperties": true,
+							"properties": {
+								"name": {
+									"description": "first element name",
+									"type": "string"
+								}
+							},
+							"required": [
+								"name"
+							],
+							"type": "object"
+						},
+						{
+							"additionalProperties": true,
+							"properties": {
+								"name": {
+									"description": "second element name",
+									"type": "string"
+								}
+							},
+							"required": [
+								"name"
+							],
+							"type": "object"
+						}
+					],
+					"maxItems": 2,
+					"minItems": 2,
+					"type": "array"
 				}
 			},
 			"required": [
@@ -64,7 +98,8 @@
 				"c",
 				"e",
 				"g",
-				"h"
+				"h",
+				"i"
 			],
 			"type": "object"
 		}

--- a/test/expected/comments/schema.json
+++ b/test/expected/comments/schema.json
@@ -1,0 +1,51 @@
+{
+	"$schema": "http://json-schema.org/draft-07/schema#",
+	"additionalProperties": true,
+	"properties": {
+		"an_object_with_optional": {
+			"additionalProperties": true,
+			"description": "This is a nested object with comments",
+			"properties": {
+				"a": {
+					"description": "This is A",
+					"type": "string"
+				},
+				"b": {
+					"description": "This is B",
+					"type": "number"
+				},
+				"c": {
+					"type": "boolean"
+				},
+				"d": {
+					"type": "string"
+				},
+				"e": {
+					"additionalProperties": true,
+					"description": "This is E",
+					"examples": ["This is a multi-line\nexample."],
+					"properties": {
+						"a": {
+							"type": "string"
+						}
+					},
+					"required": [
+						"a"
+					],
+					"type": "object"
+				}
+			},
+			"required": [
+				"a",
+				"b",
+				"c",
+				"e"
+			],
+			"type": "object"
+		}
+	},
+	"required": [
+		"an_object_with_optional"
+	],
+	"type": "object"
+}

--- a/test/expected/comments/schema.json
+++ b/test/expected/comments/schema.json
@@ -23,7 +23,9 @@
 				"e": {
 					"additionalProperties": true,
 					"description": "This is E",
-					"examples": ["This is a multi-line\nexample."],
+					"examples": [
+						"This is a multi-line\nexample."
+					],
 					"properties": {
 						"a": {
 							"type": "string"
@@ -33,13 +35,35 @@
 						"a"
 					],
 					"type": "object"
+				},
+				"f": {
+					"deprecated": true,
+					"description": "This is F",
+					"type": "string"
+				},
+				"g": {
+					"description": "This is G",
+					"examples": [
+						"first example",
+						"second example"
+					],
+					"type": "string"
+				},
+				"h": {
+					"description": "This is H",
+					"examples": [
+						"{\n  name    = \"web-server\"\n  port    = 8080\n  enabled = true\n}"
+					],
+					"type": "string"
 				}
 			},
 			"required": [
 				"a",
 				"b",
 				"c",
-				"e"
+				"e",
+				"g",
+				"h"
 			],
 			"type": "object"
 		}

--- a/test/expected/comments/schema.json
+++ b/test/expected/comments/schema.json
@@ -55,6 +55,40 @@
 						"{\n  name    = \"web-server\"\n  port    = 8080\n  enabled = true\n}"
 					],
 					"type": "string"
+				},
+				"i": {
+					"description": "This is I",
+					"items": [
+						{
+							"additionalProperties": true,
+							"properties": {
+								"name": {
+									"description": "first element name",
+									"type": "string"
+								}
+							},
+							"required": [
+								"name"
+							],
+							"type": "object"
+						},
+						{
+							"additionalProperties": true,
+							"properties": {
+								"name": {
+									"description": "second element name",
+									"type": "string"
+								}
+							},
+							"required": [
+								"name"
+							],
+							"type": "object"
+						}
+					],
+					"maxItems": 2,
+					"minItems": 2,
+					"type": "array"
 				}
 			},
 			"required": [
@@ -63,7 +97,8 @@
 				"c",
 				"e",
 				"g",
-				"h"
+				"h",
+				"i"
 			],
 			"type": "object"
 		}

--- a/test/expected/comments/variables.json
+++ b/test/expected/comments/variables.json
@@ -17,7 +17,24 @@
 				],
 				"f": "string",
 				"g": "string",
-				"h": "string"
+				"h": "string",
+				"i": [
+					"tuple",
+					[
+						[
+							"object",
+							{
+								"name": "string"
+							}
+						],
+						[
+							"object",
+							{
+								"name": "string"
+							}
+						]
+					]
+				]
 			},
 			[
 				"d",

--- a/test/expected/comments/variables.json
+++ b/test/expected/comments/variables.json
@@ -1,0 +1,24 @@
+{
+	"an_object_with_optional": {
+		"default": null,
+		"description": "This is a nested object with comments",
+		"type": [
+			"object",
+			{
+				"a": "string",
+				"b": "number",
+				"c": "bool",
+				"d": "string",
+				"e": [
+					"object",
+					{
+						"a": "string"
+					}
+				]
+			},
+			[
+				"d"
+			]
+		]
+	}
+}

--- a/test/expected/comments/variables.json
+++ b/test/expected/comments/variables.json
@@ -14,10 +14,14 @@
 					{
 						"a": "string"
 					}
-				]
+				],
+				"f": "string",
+				"g": "string",
+				"h": "string"
 			},
 			[
-				"d"
+				"d",
+				"f"
 			]
 		]
 	}

--- a/test/modules/comments/variables.tf
+++ b/test/modules/comments/variables.tf
@@ -1,0 +1,18 @@
+# Copyright 2024 Hewlett Packard Enterprise Development LP
+
+variable "an_object_with_optional" {
+    type = object({
+        # This is A
+        a = string
+        b = number # This is B
+        c = bool
+        d = optional(string)
+        # This is E
+        # @example: This is a multi-line
+        # example.
+        e = object({
+          a = string
+        })
+    })
+    description = "This is a nested object with comments"
+}

--- a/test/modules/comments/variables.tf
+++ b/test/modules/comments/variables.tf
@@ -28,6 +28,13 @@ variable "an_object_with_optional" {
         #   enabled = true
         # }
         h = string
+        # This is I
+        i = tuple([object({
+            # first element name
+            name = string
+        }), object({
+            name = string # second element name
+        })])
     })
     description = "This is a nested object with comments"
 }

--- a/test/modules/comments/variables.tf
+++ b/test/modules/comments/variables.tf
@@ -13,6 +13,21 @@ variable "an_object_with_optional" {
         e = object({
           a = string
         })
+        # This is F
+        # @deprecated
+        f = optional(string)
+        # This is G
+        # @example: first example
+        # @example: second example
+        g = string
+        # This is H
+        # @example:
+        # {
+        #   name    = "web-server"
+        #   port    = 8080
+        #   enabled = true
+        # }
+        h = string
     })
     description = "This is a nested object with comments"
 }


### PR DESCRIPTION
## What

Adds support for add `description`, `examples`, and `deprecated` metadata to the outputted JSON Schema for deeply nested objects via comment annotations.

## Why

We have some deeply nested objects to to super-modules that pass rich objects via variables to sub-modules. This works very well, but we loose the ability to document those sub variables and surface that to end users.

## How

Adds a complimentary comment pass which grabs all the preceding and in-line comments for attributes, does some very basic parsing, and then merges that information into the main variable model. 


_Note: This PR and the code here-in was co-authored by 🤖 Claude via Claude Code_, but I personally modified and reviewed it for correctness and documentation.

